### PR TITLE
docs: add GitHub Flow branch strategy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,28 @@
 
 ---
 
+## ブランチ戦略
+
+[GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) を採用しています。
+
+1. `main` から作業ブランチを切る
+2. ブランチ上で実装・コミット
+3. PRを作成して `main` へマージ
+4. マージ後はブランチを削除
+
+```bash
+git switch -c feature/your-feature-name
+# ... 実装 ...
+git push origin feature/your-feature-name
+# → GitHub上でPRを作成
+```
+
+ブランチ名は `feature/`, `fix/`, `docs/` などのプレフィックスをつけると分かりやすいです。
+
+`main` への直pushはブランチ保護により禁止されています。
+
+---
+
 ## プルリクエスト
 
 ### 開発環境のセットアップ


### PR DESCRIPTION
## 変更内容

CONTRIBUTING.md にブランチ戦略（GitHub Flow）のセクションを追加。

- ブランチの切り方・PRの流れを明記
- ブランチ名のプレフィックス規則を記載
- main への直push禁止についても言及

## 関連Issue

なし

## 動作確認

- [x] `go build` が通る
- [x] ドキュメントのみの変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* コントリビューションガイドに新たにブランチ戦略（GitHub Flow）に関するセクションを追加しました。ブランチの命名規則およびgitコマンドの実行例が含まれています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->