### PR TITLE
Add tmux socket isolation via -L flag and improve Setup screen

### DIFF
--- a/documents/screen-flow.md
+++ b/documents/screen-flow.md
@@ -1,0 +1,180 @@
+# lazyprj 画面フロー図
+
+## 全体画面遷移
+
+オーバーレイ画面（Editor / Scan / Quickstart）は閉じると常に Main に戻る。
+
+```mermaid
+flowchart TD
+    START([起動]) --> LOAD[設定ファイル読み込み]
+    LOAD -->|ScanDirectory が空| SETUP[Setup 画面\nスキャンディレクトリ設定]
+    LOAD -->|設定済み| MAIN[Main 画面\nプロジェクト一覧]
+
+    SETUP -->|完了 / スキップ| MAIN
+
+    MAIN --> EDITOR[Editor 画面\n※オーバーレイ]
+    MAIN --> SCAN[Scan 画面\n※オーバーレイ]
+    MAIN --> SETUP
+    MAIN --> QUICKSTART[Quickstart 画面\n※オーバーレイ]
+    MAIN -->|セッションアタッチ| TMUX([tmux アタッチ\n※アプリ終了])
+```
+
+---
+
+## Main 画面
+
+プロジェクト一覧と詳細を表示するメイン画面。
+
+```mermaid
+flowchart LR
+    subgraph MAIN_SCREEN[Main 画面]
+        direction TB
+        LEFT[プロジェクトリスト\n左パネル]
+        RIGHT[プロジェクト詳細\n右パネル]
+        STATUSBAR[ステータスバー]
+        KEYHINTS[キーヒント]
+    end
+```
+
+---
+
+## Setup 画面（フルスクリーン）
+
+初回起動時または `S` キーで表示。スキャンディレクトリのパスを入力する。
+
+```mermaid
+flowchart TD
+    SETUP_START([Setup 画面表示]) --> INPUT[パス入力フォーム]
+    INPUT -->|保存| SAVE[設定保存]
+    INPUT -->|スキップ\n既存設定がある場合のみ| SKIP[スキップ]
+    SAVE --> MAIN([Main 画面へ])
+    SKIP --> MAIN
+```
+
+**表示条件:**
+- 初回起動時（`ScanDirectory` が空）→ 自動遷移
+- Main 画面で `S` キー押下
+
+---
+
+## Editor 画面（オーバーレイ）
+
+Main 画面の上に重なって表示される。プロジェクトのウィンドウ・ペイン構成を編集する。
+
+ウィンドウリストとペインリストは Tab で相互に切り替え可能。
+
+```mermaid
+flowchart LR
+    START([Editor 画面表示]) --> WIN_LIST[ウィンドウリスト]
+    WIN_LIST -->|切り替え| PANE_LIST[ペインリスト]
+
+    WIN_LIST -->|追加 / 編集| WIN_FORM[ウィンドウフォーム]
+    WIN_FORM -->|確定 / キャンセル| WIN_LIST
+
+    PANE_LIST -->|追加 / 編集| PANE_FORM[ペインフォーム]
+    PANE_FORM -->|確定 / キャンセル| PANE_LIST
+
+    WIN_LIST -->|保存 / 閉じる| MAIN([Main 画面へ])
+    PANE_LIST -->|保存 / 閉じる| MAIN
+```
+
+---
+
+## Scan 画面（オーバーレイ）
+
+Main 画面の上に重なって表示される。スキャンディレクトリ配下の未登録プロジェクトを一覧表示し、登録するプロジェクトを選択する。
+
+```mermaid
+flowchart TD
+    SCAN_START([Scan 画面表示]) --> LOADING[スキャン中...]
+    LOADING --> LIST[プロジェクト一覧]
+
+    LIST -->|スキップ済み表示切替| LIST
+    LIST -->|登録| SAVE[設定に追加保存]
+    LIST -->|閉じる| MAIN([Main 画面へ])
+
+    SAVE --> MAIN
+```
+
+---
+
+## Quickstart 画面（オーバーレイ）
+
+Main 画面の上に重なって表示される。任意ディレクトリを指定して即座にtmuxセッションを作成する。
+
+```mermaid
+flowchart TD
+    QS_START([Quickstart 画面表示]) --> DIR_INPUT[ディレクトリパス入力]
+    DIR_INPUT -->|次へ| NAME_INPUT[セッション名入力]
+    NAME_INPUT -->|戻る| DIR_INPUT
+    NAME_INPUT -->|作成| CREATE[セッション作成 & 設定に追加]
+    DIR_INPUT -->|閉じる| MAIN([Main 画面へ])
+    NAME_INPUT -->|閉じる| MAIN
+    CREATE --> MAIN
+```
+
+---
+
+## オーバーレイ一覧
+
+```mermaid
+flowchart TD
+    subgraph MAIN_BASE[Main 画面（ベース）]
+        BASE[プロジェクト一覧 + 詳細]
+    end
+
+    subgraph OVERLAYS[オーバーレイ層]
+        OV1[Editor 画面\nウィンドウ/ペイン編集]
+        OV2[Scan 画面\n新規プロジェクト登録]
+        OV3[Quickstart 画面\nセッション即時作成]
+        OV4[Help ダイアログ\nキー一覧]
+        OV5[確認ダイアログ\nセッション再起動確認]
+        OV6[Sync 確認ダイアログ\n設定変更の同期確認]
+    end
+
+    subgraph FULLSCREEN[フルスクリーン]
+        FS1[Setup 画面\nスキャンディレクトリ設定]
+    end
+
+    MAIN_BASE --> OV1
+    MAIN_BASE --> OV2
+    MAIN_BASE --> OV3
+    MAIN_BASE --> OV4
+    MAIN_BASE --> OV5
+    MAIN_BASE --> OV6
+    MAIN_BASE -.->|置き換え| FS1
+```
+
+> **オーバーレイ**: Main 画面がバックグラウンドに透けて見える状態でダイアログが前面表示される
+>
+> **フルスクリーン**: Main 画面を完全に置き換えて表示される（Setup のみ）
+
+---
+
+## 起動フロー
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant App as lazyprj
+    participant Config as 設定ファイル
+    participant Tmux as tmux
+
+    User->>App: 起動
+    App->>Config: 設定読み込み
+    alt ScanDirectory が未設定
+        App-->>User: Setup 画面表示
+        User->>App: パス入力 + Enter
+        App->>Config: ScanDirectory 保存
+    end
+    App-->>User: Main 画面表示
+    alt 初回起動 & tmuxセッションなし & AutoStart プロジェクトあり
+        App->>Tmux: AutoStart プロジェクトを一括起動
+    end
+    User->>App: Enter/s（セッション選択）
+    alt セッション未起動
+        App->>Tmux: セッション作成
+    end
+    App->>Tmux: アタッチ（アプリ終了後）
+    Tmux-->>User: tmux セッションへ
+```

--- a/documents/socket.md
+++ b/documents/socket.md
@@ -1,0 +1,83 @@
+# tmux ソケット分離 (`-L` オプション)
+
+`-L` オプションを使うと、tmux サーバーと設定ファイルをまるごと分離した状態で lazyprj を起動できます。
+
+---
+
+## 使い方
+
+```bash
+./lazyprj -L <ソケット名>
+```
+
+### 例
+
+```bash
+# 通常起動（デフォルト）
+./lazyprj
+
+# "demo" という名前のソケットで起動
+./lazyprj -L demo
+```
+
+---
+
+## `-L` を指定したときの挙動
+
+| 項目 | 通常起動 | `-L demo` 指定時 |
+|------|----------|-----------------|
+| tmux サーバー | デフォルトソケット | `lazyprj-demo` ソケット |
+| 設定ファイル | `~/.config/lazyprj/config.json` | `~/.config/lazyprj/config-demo.json` |
+
+tmux サーバーと設定ファイルの両方が分離されるため、通常の作業環境に一切影響しません。
+
+---
+
+## デモ・スクリーンショット用途
+
+README 等に掲載する画像を撮影するとき、通常の作業セッションを汚さずにクリーンな状態を作れます。
+
+### 初回起動フロー（setup 画面から）のデモ
+
+```bash
+# 設定ファイルが存在しない状態で起動 → setup 画面から始まる
+./lazyprj -L demo
+```
+
+`config-demo.json` が存在しない場合、自動的に setup 画面へ遷移します。
+通常の `config.json` はそのまま保持されます。
+
+### セッションがゼロの状態からのデモ
+
+```bash
+# demo ソケットには tmux サーバーが存在しないため、全プロジェクトが停止中で表示される
+./lazyprj -L demo
+```
+
+lazyprj 上でセッションを起動する操作から順にデモできます。
+
+---
+
+## デモ環境のリセット
+
+```bash
+# tmux サーバーを停止（セッションをすべて破棄）
+tmux -L demo kill-server
+
+# 設定ファイルを削除（初回起動フローに戻す）
+rm ~/.config/lazyprj/config-demo.json
+```
+
+両方実行すれば完全にまっさらな状態に戻ります。
+
+---
+
+## 複数環境の使い分け
+
+ソケット名ごとに独立した環境を持てるため、用途に応じて使い分けられます。
+
+```bash
+./lazyprj -L work     # 仕事用（config-work.json + work ソケット）
+./lazyprj -L personal # 個人用（config-personal.json + personal ソケット）
+./lazyprj -L demo     # デモ用（config-demo.json + demo ソケット）
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,9 +91,22 @@ func configDir() string {
 	return filepath.Join(home, ".config", "lazyprj")
 }
 
-// GetConfigPath は設定ファイルのパスを返す
+var configSocket string
+
+// SetSocket はソケット名を設定する。空でない場合、config ファイル名が
+// config-<socket>.json になる。
+func SetSocket(s string) {
+	configSocket = s
+}
+
+// GetConfigPath は設定ファイルのパスを返す。
+// ソケット名が指定されている場合は config-<socket>.json を使用する。
 func GetConfigPath() string {
-	return filepath.Join(configDir(), "config.json")
+	name := "config.json"
+	if configSocket != "" {
+		name = "config-" + configSocket + ".json"
+	}
+	return filepath.Join(configDir(), name)
 }
 
 // Load は設定ファイルを読み込む

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -10,8 +10,24 @@ import (
 	"github.com/masaway/lazyprj/internal/config"
 )
 
+var socket string
+
+// SetSocket は使用する tmux ソケット名を設定する（例: "lazyprj-demo"）。
+// 空文字の場合はデフォルトソケットを使用する。
+func SetSocket(s string) {
+	socket = s
+}
+
+// socketArgs は tmux コマンドに -L <socket> を付加するための引数を返す
+func socketArgs(args []string) []string {
+	if socket == "" {
+		return args
+	}
+	return append([]string{"-L", socket}, args...)
+}
+
 func run(args ...string) (int, string) {
-	cmd := exec.Command("tmux", args...)
+	cmd := exec.Command("tmux", socketArgs(args)...)
 	out, _ := cmd.CombinedOutput()
 	err := cmd.Wait()
 	if err != nil {
@@ -24,7 +40,7 @@ func run(args ...string) (int, string) {
 }
 
 func runCmd(args ...string) (int, string) {
-	cmd := exec.Command("tmux", args...)
+	cmd := exec.Command("tmux", socketArgs(args)...)
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -205,9 +221,9 @@ func InspectSession(name string) []config.Window {
 // AttachOrSwitch はtmux内ならswitch-client、外ならattach-sessionを実行する
 func AttachOrSwitch(name string) error {
 	if os.Getenv("TMUX") != "" {
-		return exec.Command("tmux", "switch-client", "-t", name).Run()
+		return exec.Command("tmux", socketArgs([]string{"switch-client", "-t", name})...).Run()
 	}
-	cmd := exec.Command("tmux", "attach-session", "-t", name)
+	cmd := exec.Command("tmux", socketArgs([]string{"attach-session", "-t", name})...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -306,8 +306,14 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			result, cmd := m.setup.Update(msg)
 			m.setup = result.(*SetupModel)
 			if m.setup.IsDone() {
+				skipped := m.setup.IsSkipped()
 				m.currentScreen = screenMain
 				m.setup = nil
+				if skipped {
+					// スキップ時はリロードしない（再度reloadedMsgが来ないのでsetup画面も出ない）
+					// 次回起動時はScanDirectoryが空なので再度setup画面に遷移する
+					return m, nil
+				}
 				return m, reloadCmd
 			}
 			return m, cmd

--- a/internal/ui/setup.go
+++ b/internal/ui/setup.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -17,6 +18,7 @@ type SetupModel struct {
 	cfg           *config.Config
 	canSkip       bool // 既存の値があればEscでスキップ可
 	done          bool
+	skipped       bool // Escで設定せずに閉じた
 	status        string
 	statusIsErr   bool
 }
@@ -32,6 +34,8 @@ func NewSetup(cfg *config.Config) *SetupModel {
 	canSkip := cfg.Settings.ScanDirectory != ""
 	if canSkip {
 		ti.SetValue(cfg.Settings.ScanDirectory)
+	} else if cwd, err := os.Getwd(); err == nil {
+		ti.SetValue(cwd)
 	}
 	ti.Focus()
 
@@ -44,7 +48,8 @@ func NewSetup(cfg *config.Config) *SetupModel {
 
 func (m *SetupModel) Init() tea.Cmd { return textinput.Blink }
 
-func (m *SetupModel) IsDone() bool { return m.done }
+func (m *SetupModel) IsDone() bool    { return m.done }
+func (m *SetupModel) IsSkipped() bool { return m.skipped }
 
 func (m *SetupModel) Resize(w, h int) {
 	m.width = w
@@ -81,10 +86,12 @@ func (m *SetupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "esc":
-			if m.canSkip {
-				m.done = true
-			}
+			m.done = true
+			m.skipped = !m.canSkip // 既存値なしでスキップした場合はフラグを立てる
 			return m, nil
+
+		case "ctrl+c", "q":
+			return m, tea.Quit
 		}
 	}
 
@@ -133,9 +140,9 @@ func (m *SetupModel) View() string {
 func (m *SetupModel) renderKeys() string {
 	var hints []struct{ key, desc string }
 	if m.canSkip {
-		hints = []struct{ key, desc string }{{"Enter", "保存"}, {"Esc", "キャンセル"}}
+		hints = []struct{ key, desc string }{{"Enter", "保存"}, {"Esc", "キャンセル"}, {"q", "終了"}}
 	} else {
-		hints = []struct{ key, desc string }{{"Enter", "保存"}}
+		hints = []struct{ key, desc string }{{"Enter", "保存"}, {"Esc", "後で設定"}, {"q", "終了"}}
 	}
 	var parts []string
 	for _, h := range hints {

--- a/main.go
+++ b/main.go
@@ -1,16 +1,27 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/masaway/lazyprj/internal/config"
 	"github.com/masaway/lazyprj/internal/tmux"
 	"github.com/masaway/lazyprj/internal/ui"
 )
 
 func main() {
+	var socketName string
+	flag.StringVar(&socketName, "L", "", "使用する tmux ソケット名（例: lazyprj-demo）")
+	flag.Parse()
+
+	if socketName != "" {
+		tmux.SetSocket(socketName)
+		config.SetSocket(socketName)
+	}
+
 	app := ui.New()
 
 	p := tea.NewProgram(


### PR DESCRIPTION
## Summary

- `-L <socket>` フラグを追加し、tmux サーバーと設定ファイルをソケット名ごとに分離できるようにした（デモ・スクリーンショット用途を想定）
- Setup 画面のスキップ挙動を修正：`IsSkipped()` を追加し、スキップ時に無限リロードループが発生しないよう対処
- Setup 画面の初期値として現在のディレクトリを自動入力、初回起動時も Esc でスキップ可能に
- `documents/socket.md`：`-L` オプションの使い方・ユースケースを説明するドキュメントを追加
- `documents/screen-flow.md`：Mermaid 記法による画面遷移フロー図を追加

## Test plan

- [ ] `./lazyprj` で通常起動し、既存の動作に影響がないことを確認
- [ ] `./lazyprj -L demo` で起動し、`config-demo.json` が生成されること・tmux セッションがデフォルトと分離されることを確認
- [ ] 初回起動（config なし）で Setup 画面が表示され、Esc で「後で設定」として Main に戻れることを確認
- [ ] Setup 画面で既存設定ありの場合、Esc でスキップできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)