### PR TITLE
Fix multiple issues: attach, UI, sort, hidden projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config/personal.json
 
 # Temp / scratch files
 追加.md
+plan/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,9 +52,10 @@ type Settings struct {
 
 // Config は設定ファイル全体
 type Config struct {
-	Projects     []Project `json:"projects"`
-	SkippedPaths []string  `json:"skipped_paths,omitempty"`
-	Settings     Settings  `json:"settings"`
+	Projects       []Project `json:"projects"`
+	HiddenProjects []Project `json:"hidden_projects,omitempty"`
+	SkippedPaths   []string  `json:"skipped_paths,omitempty"`
+	Settings       Settings  `json:"settings"`
 }
 
 func (p *Project) HasWindows() bool {
@@ -71,7 +72,7 @@ func (p *Project) MigrateFromCommands() {
 		panes = append(panes, Pane{Dir: ".", Command: p.Commands.Dev})
 	}
 	w := Window{
-		Name:   "dev",
+		Name:   "main",
 		Layout: "even-horizontal",
 		Panes:  panes,
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -218,10 +218,20 @@ func InspectSession(name string) []config.Window {
 	return windows
 }
 
+// IsInsideTmux は現在tmuxセッション内で実行されているかを返す
+func IsInsideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
+// SwitchClient はtmuxのswitch-clientを実行する（tmux内専用）
+func SwitchClient(name string) error {
+	return exec.Command("tmux", socketArgs([]string{"switch-client", "-t", name})...).Run()
+}
+
 // AttachOrSwitch はtmux内ならswitch-client、外ならattach-sessionを実行する
 func AttachOrSwitch(name string) error {
-	if os.Getenv("TMUX") != "" {
-		return exec.Command("tmux", socketArgs([]string{"switch-client", "-t", name})...).Run()
+	if IsInsideTmux() {
+		return SwitchClient(name)
 	}
 	cmd := exec.Command("tmux", socketArgs([]string{"attach-session", "-t", name})...)
 	cmd.Stdin = os.Stdin

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -46,6 +47,9 @@ type App struct {
 	pendingAttach string
 	initialLoad   bool
 
+	sortActiveFirst   bool
+	originalProjects []config.Project // ソート前の順序を保持
+
 	detailScroll int
 	listScroll   int
 
@@ -83,6 +87,55 @@ func (m *App) PendingAttach() string {
 	return m.pendingAttach
 }
 
+// applySortProjects はアクティブ優先でプロジェクトをソートする
+func (m *App) applySortProjects() {
+	if m.cfg == nil {
+		return
+	}
+	currentName := ""
+	if m.cursor < len(m.cfg.Projects) {
+		currentName = m.cfg.Projects[m.cursor].Name
+	}
+	m.originalProjects = make([]config.Project, len(m.cfg.Projects))
+	copy(m.originalProjects, m.cfg.Projects)
+	sort.SliceStable(m.cfg.Projects, func(i, j int) bool {
+		ai := m.sessions[m.cfg.Projects[i].Name]
+		aj := m.sessions[m.cfg.Projects[j].Name]
+		if ai != aj {
+			return ai
+		}
+		if m.cfg.Projects[i].AutoStart != m.cfg.Projects[j].AutoStart {
+			return m.cfg.Projects[i].AutoStart
+		}
+		return m.cfg.Projects[i].Name < m.cfg.Projects[j].Name
+	})
+	for i, p := range m.cfg.Projects {
+		if p.Name == currentName {
+			m.cursor = i
+			break
+		}
+	}
+}
+
+// restoreProjectOrder は元の順序に戻す
+func (m *App) restoreProjectOrder() {
+	if m.cfg == nil || m.originalProjects == nil {
+		return
+	}
+	currentName := ""
+	if m.cursor < len(m.cfg.Projects) {
+		currentName = m.cfg.Projects[m.cursor].Name
+	}
+	m.cfg.Projects = m.originalProjects
+	m.originalProjects = nil
+	for i, p := range m.cfg.Projects {
+		if p.Name == currentName {
+			m.cursor = i
+			break
+		}
+	}
+}
+
 // ─── メッセージ ───────────────────────────────────────────────────────────────
 
 type reloadedMsg struct {
@@ -106,6 +159,9 @@ type sessionRestartedMsg struct {
 	err  error
 }
 
+type switchClientMsg struct {
+	err error
+}
 
 type windowSyncChoice struct {
 	projectName  string
@@ -226,6 +282,12 @@ func commitSyncCmd(cfg *config.Config, sessions map[string]bool) tea.Cmd {
 	}
 }
 
+func switchClientCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		return switchClientMsg{err: tmux.SwitchClient(name)}
+	}
+}
+
 func startSessionCmd(p config.Project, kill bool) tea.Cmd {
 	return func() tea.Msg {
 		created, err := tmux.CreateSession(&p, kill)
@@ -342,8 +404,12 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case reloadedMsg:
 		m.cfg = msg.cfg
 		m.sessions = msg.sessions
+		m.originalProjects = nil
 		if m.cfg != nil && m.cursor >= len(m.cfg.Projects) {
 			m.cursor = max(0, len(m.cfg.Projects)-1)
+		}
+		if m.sortActiveFirst {
+			m.applySortProjects()
 		}
 		if m.status == "更新中..." {
 			m.status = ""
@@ -393,8 +459,17 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusIsErr = false
 			return m, reloadCmd
 		} else {
+			if tmux.IsInsideTmux() {
+				return m, switchClientCmd(msg.name)
+			}
 			m.pendingAttach = msg.name
 			return m, tea.Quit
+		}
+
+	case switchClientMsg:
+		if msg.err != nil {
+			m.status = fmt.Sprintf("エラー: %s", msg.err)
+			m.statusIsErr = true
 		}
 
 	case sessionKilledMsg:
@@ -510,6 +585,9 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		p := m.cfg.Projects[m.cursor]
 		if m.sessions[p.Name] {
+			if tmux.IsInsideTmux() {
+				return m, switchClientCmd(p.Name)
+			}
 			m.pendingAttach = p.Name
 			return m, tea.Quit
 		}
@@ -575,6 +653,21 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusIsErr = false
 		}
 
+	case "o":
+		if m.cfg == nil {
+			break
+		}
+		m.sortActiveFirst = !m.sortActiveFirst
+		if m.sortActiveFirst {
+			m.applySortProjects()
+			m.status = "ソート: アクティブ優先"
+		} else {
+			m.restoreProjectOrder()
+			m.status = "ソート: 登録順"
+		}
+		m.statusIsErr = false
+		m.listScroll = 0
+
 	case "A":
 		if m.cfg == nil {
 			break
@@ -600,6 +693,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		p := m.cfg.Projects[m.cursor]
 		m.cfg.Projects = append(m.cfg.Projects[:m.cursor], m.cfg.Projects[m.cursor+1:]...)
+		m.cfg.HiddenProjects = append(m.cfg.HiddenProjects, p)
 		m.cfg.SkippedPaths = append(m.cfg.SkippedPaths, p.Path)
 		if m.cursor >= len(m.cfg.Projects) && m.cursor > 0 {
 			m.cursor--

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -439,6 +439,12 @@ func (m *EditorModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.panel = editorPanelWindows
 		}
 
+	case "1":
+		m.panel = editorPanelWindows
+
+	case "2":
+		m.panel = editorPanelPanes
+
 	case "j", "down":
 		if m.panel == editorPanelWindows {
 			if m.winCursor < len(m.project.Windows)-1 {
@@ -679,7 +685,17 @@ func (m *EditorModel) renderWindowPanel(totalW, totalH int) string {
 				))
 			}
 		} else {
-			lines = append(lines, fmt.Sprintf("   %s%s", styleNormal.Render(w.Name), layoutSuffix))
+			rawSuffix := ""
+			if isNamedLayout(w.Layout) {
+				rawSuffix = "  " + w.Layout
+			} else if w.Layout != "" {
+				rawSuffix = "  [カスタム]"
+			}
+			nameMaxW := innerW - 3 - runewidth.StringWidth(rawSuffix)
+			if nameMaxW < 1 {
+				nameMaxW = 1
+			}
+			lines = append(lines, fmt.Sprintf("   %s%s", styleNormal.Render(truncateStr(w.Name, nameMaxW)), layoutSuffix))
 		}
 	}
 
@@ -728,21 +744,21 @@ func (m *EditorModel) renderPanePanel(totalW, totalH int) string {
 				cmdMaxW = 4
 			}
 
+			execBotPrefix := "          "
+			if pane.Execute {
+				execBotPrefix = "        ▶ "
+			}
 			top := fmt.Sprintf(" pane %d  %s  %s", i, execStr, styleDim.Render(truncateStr(dir, dirMaxW)))
-			bot := fmt.Sprintf("          %s", styleYellow.Render(truncateStr(cmd, cmdMaxW)))
+			bot := fmt.Sprintf("%s%s", execBotPrefix, styleYellow.Render(truncateStr(cmd, cmdMaxW)))
 
 			if i == m.paneCursor {
 				if m.panel == editorPanelPanes {
-					execRaw := "▷"
-					if pane.Execute {
-						execRaw = "▶"
-					}
 					top = styleSelectedItem.Width(innerW).Render(
-						fmt.Sprintf(" pane %d  %s  %s", i, execRaw, truncateStr(dir, dirMaxW)),
+						fmt.Sprintf(" pane %d  %s  %s", i, execStr, truncateStr(dir, dirMaxW)),
 					)
 					bot = lipgloss.NewStyle().
 						Background(colorBg2).Foreground(colorYellow).Width(innerW).
-						Render(fmt.Sprintf("          %s", truncateStr(cmd, cmdMaxW)))
+						Render(fmt.Sprintf("%s%s", execBotPrefix, truncateStr(cmd, cmdMaxW)))
 				} else {
 					top = lipgloss.NewStyle().Foreground(colorCyan).Render(top)
 				}

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -265,10 +265,15 @@ func (m *ScanModel) unskipCmd(si int) tea.Cmd {
 func (m *ScanModel) saveCmd() tea.Cmd {
 	for i, p := range m.projects {
 		if m.selected[i] {
-			m.cfg.Projects = append(m.cfg.Projects, config.Project{
-				Name: p.Name,
-				Path: p.Path,
-			})
+			proj := config.Project{Name: p.Name, Path: p.Path}
+			for j, hp := range m.cfg.HiddenProjects {
+				if hp.Path == p.Path {
+					proj = hp
+					m.cfg.HiddenProjects = append(m.cfg.HiddenProjects[:j], m.cfg.HiddenProjects[j+1:]...)
+					break
+				}
+			}
+			m.cfg.Projects = append(m.cfg.Projects, proj)
 		}
 	}
 	cfg := m.cfg


### PR DESCRIPTION
## Summary

- **#1** プロジェクト一覧にソート機能を追加（`o` キーでトグル）: 起動中 → AutoStart → 名前順
- **#2** プロジェクト非表示時に設定を `HiddenProjects` に保存し、スキャン画面から復元時にフル設定を復元
- **#3** 初期ウィンドウ名のデフォルトを `dev` → `main` に変更
- **#4** 編集画面で `1`/`2` キーによるパネル切り替えを追加
- **#5** 編集画面のウィンドウ一覧で非選択行のテキストが枠をはみ出すレイアウト崩れを修正
- **#6** execute=on のペインにコマンド行で `▶` プレフィックスを表示
- tmux 内でセッションにアタッチする際、`switch-client` を使いアプリを閉じないよう変更

## Test plan

- [ ] tmux 内でセッションにアタッチし、muxflow が閉じずに残ることを確認
- [ ] `o` キーでソートが切り替わること、リロード後も維持されることを確認
- [ ] プロジェクトを `X` で非表示→スキャン画面で復元時にウィンドウ設定が保持されることを確認
- [ ] 編集画面で `1`/`2` キーでパネル切り替えができることを確認
- [ ] 長いウィンドウ名でレイアウトが崩れないことを確認
- [ ] execute=on のペインでコマンド行に `▶` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)