### PR TITLE
Revamp keybindings for consistency (Issue #14)

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -107,7 +107,7 @@ func (m *App) applySortProjects() {
 		if m.cfg.Projects[i].AutoStart != m.cfg.Projects[j].AutoStart {
 			return m.cfg.Projects[i].AutoStart
 		}
-		return m.cfg.Projects[i].Name < m.cfg.Projects[j].Name
+		return false
 	})
 	for i, p := range m.cfg.Projects {
 		if p.Name == currentName {
@@ -529,6 +529,12 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.focus = panelProjects
 		}
 
+	case "h":
+		m.focus = panelProjects
+
+	case "l":
+		m.focus = panelDetail
+
 	case "1":
 		m.focus = panelProjects
 
@@ -579,7 +585,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.adjustListScroll()
 		}
 
-	case "enter", "s":
+	case "enter":
 		if m.cfg == nil || len(m.cfg.Projects) == 0 {
 			break
 		}
@@ -595,7 +601,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.statusIsErr = false
 		return m, startSessionCmd(p, false)
 
-	case "d", "x":
+	case "x":
 		if m.cfg == nil || len(m.cfg.Projects) == 0 {
 			break
 		}
@@ -663,7 +669,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = "ソート: アクティブ優先"
 		} else {
 			m.restoreProjectOrder()
-			m.status = "ソート: 登録順"
+			m.status = "ソート: カスタム順"
 		}
 		m.statusIsErr = false
 		m.listScroll = 0
@@ -707,13 +713,51 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, reloadCmd
 
-	case "n":
+	case "K":
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor == 0 {
+			break
+		}
+		if m.sortActiveFirst {
+			m.restoreProjectOrder()
+			m.sortActiveFirst = false
+		}
+		m.cfg.Projects[m.cursor], m.cfg.Projects[m.cursor-1] = m.cfg.Projects[m.cursor-1], m.cfg.Projects[m.cursor]
+		m.cursor--
+		m.adjustListScroll()
+		if err := config.Save(m.cfg); err != nil {
+			m.status = fmt.Sprintf("保存エラー: %v", err)
+			m.statusIsErr = true
+		} else {
+			m.status = ""
+			m.statusIsErr = false
+		}
+
+	case "J":
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects)-1 {
+			break
+		}
+		if m.sortActiveFirst {
+			m.restoreProjectOrder()
+			m.sortActiveFirst = false
+		}
+		m.cfg.Projects[m.cursor], m.cfg.Projects[m.cursor+1] = m.cfg.Projects[m.cursor+1], m.cfg.Projects[m.cursor]
+		m.cursor++
+		m.adjustListScroll()
+		if err := config.Save(m.cfg); err != nil {
+			m.status = fmt.Sprintf("保存エラー: %v", err)
+			m.statusIsErr = true
+		} else {
+			m.status = ""
+			m.statusIsErr = false
+		}
+
+	case "s":
 		m.scanner = NewScanner(m.cfg)
 		m.scanner.Resize(m.width, m.height)
 		m.currentScreen = screenScan
 		return m, m.scanner.LoadCmd()
 
-	case "c":
+	case "n":
 		if m.cfg != nil {
 			m.quickstart = NewQuickstart(m.cfg)
 			m.quickstart.Resize(m.width, m.height)
@@ -895,7 +939,7 @@ func (m *App) renderKeyHints() string {
 	type hint struct{ key, desc string }
 	hints := []hint{
 		{"Enter", "起動/アタッチ"}, {"e", "編集"},
-		{"a", "自動起動"}, {"c", "新規作成"}, {"n", "スキャン"}, {"?", "ヘルプ"},
+		{"a", "自動起動"}, {"n", "新規作成"}, {"s", "スキャン"}, {"?", "ヘルプ"},
 	}
 	var parts []string
 	for _, h := range hints {
@@ -915,24 +959,30 @@ func (m *App) renderHelpDialog(bg string) string {
 	}
 	sections := []section{
 		{"ナビゲーション", []entry{
+			{"j / k", "上 / 下移動"},
+			{"h / l", "左 / 右パネル移動"},
 			{"g / G", "先頭 / 末尾"},
 			{"Tab", "フォーカス切替"},
 			{"1 / 2", "フォーカス直接指定"},
 		}},
 		{"セッション", []entry{
-			{"Enter / s", "起動 / アタッチ"},
-			{"d / x", "停止"},
+			{"Enter", "起動 / アタッチ"},
+			{"x", "停止"},
 			{"R", "再起動（確認あり）"},
+			{"r", "設定再読み込み・同期"},
 		}},
 		{"プロジェクト", []entry{
 			{"e", "編集"},
-			{"c", "新規セッション作成"},
+			{"n", "新規セッション作成"},
 			{"a", "自動起動トグル"},
 			{"A", "自動起動を全て起動"},
+			{"K / J", "順番を上 / 下に移動"},
+			{"o", "ソート切替（アクティブ優先 / カスタム順）"},
 			{"X", "スキップ済みへ移動"},
-			{"n", "スキャン"},
-			{"S", "スキャン先ディレクトリ"},
-			{"r", "設定再読み込み"},
+		}},
+		{"スキャン", []entry{
+			{"s", "スキャン実行"},
+			{"S", "スキャン先ディレクトリ設定"},
 		}},
 		{"その他", []entry{
 			{"?", "ヘルプ"},
@@ -940,17 +990,41 @@ func (m *App) renderHelpDialog(bg string) string {
 		}},
 	}
 
-	keyStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Width(12)
+	const keyW = 12
+	keyStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Width(keyW)
 	descStyle := lipgloss.NewStyle().Foreground(colorFg)
 	secTitleStyle := lipgloss.NewStyle().Foreground(colorPurple).Bold(true)
 	bdrStyle := lipgloss.NewStyle().Foreground(colorBorder)
 	dimStyle := lipgloss.NewStyle().Foreground(colorFgDim)
 
-	// colContentW = 実際のコンテンツ幅（key 12 + space 1 + desc 最大 ~22 = 35 以上必要）
 	colContentW := 40
 	pad := 2
-	// colStyle の Width は外側の幅 = colContentW + pad*2
 	colStyle := lipgloss.NewStyle().Width(colContentW + pad*2).Padding(1, pad)
+	descMaxW := colContentW - keyW - 1
+	descIndent := strings.Repeat(" ", keyW+1)
+
+	wrapDesc := func(text string) string {
+		if runewidth.StringWidth(text) <= descMaxW {
+			return text
+		}
+		var lines []string
+		var cur strings.Builder
+		curW := 0
+		for _, r := range text {
+			rw := runewidth.RuneWidth(r)
+			if curW+rw > descMaxW && cur.Len() > 0 {
+				lines = append(lines, cur.String())
+				cur.Reset()
+				curW = 0
+			}
+			cur.WriteRune(r)
+			curW += rw
+		}
+		if cur.Len() > 0 {
+			lines = append(lines, cur.String())
+		}
+		return strings.Join(lines, "\n"+descIndent)
+	}
 
 	renderSection := func(sec section) string {
 		lines := []string{
@@ -958,13 +1032,13 @@ func (m *App) renderHelpDialog(bg string) string {
 			bdrStyle.Render(strings.Repeat("─", colContentW)),
 		}
 		for _, e := range sec.entries {
-			lines = append(lines, keyStyle.Render(e.key)+" "+descStyle.Render(e.desc))
+			lines = append(lines, keyStyle.Render(e.key)+" "+descStyle.Render(wrapDesc(e.desc)))
 		}
 		return strings.Join(lines, "\n")
 	}
 
 	leftBlock := colStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
-		renderSection(sections[0]), "", renderSection(sections[1]),
+		renderSection(sections[0]), "", renderSection(sections[1]), "", renderSection(sections[4]),
 	))
 	rightBlock := colStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
 		renderSection(sections[2]), "", renderSection(sections[3]),

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -60,9 +60,10 @@ type EditorModel struct {
 	paneForm paneFormState
 	winForm  windowFormState
 
-	status     string
+	status      string
 	statusIsErr bool
-	done       bool
+	done        bool
+	showHelp    bool
 }
 
 type paneFormState struct {
@@ -233,7 +234,7 @@ func (m *EditorModel) updateForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.formMode = editorFormNone
 			return m, nil
 
-		case "enter", "w":
+		case "enter", "w", "ctrl+s":
 			// テキスト入力フォーカス中は w をそのままテキスト入力に渡す
 			if key.String() == "w" {
 				if m.formMode == editorFormPane && (m.paneForm.dirInputMode || m.paneForm.focus == 1) {
@@ -425,11 +426,22 @@ func (m *EditorModel) commitWindowForm() (tea.Model, tea.Cmd) {
 }
 
 func (m *EditorModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.showHelp {
+		switch key.String() {
+		case "?", "esc", "q":
+			m.showHelp = false
+		}
+		return m, nil
+	}
+
 	switch key.String() {
+	case "?":
+		m.showHelp = true
+
 	case "esc":
 		m.done = true
 
-	case "w":
+	case "w", "ctrl+s":
 		return m, m.saveCmd()
 
 	case "tab":
@@ -438,6 +450,12 @@ func (m *EditorModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.panel = editorPanelWindows
 		}
+
+	case "h":
+		m.panel = editorPanelWindows
+
+	case "l":
+		m.panel = editorPanelPanes
 
 	case "1":
 		m.panel = editorPanelWindows
@@ -609,6 +627,10 @@ func (m *EditorModel) View() string {
 		return overlayCenter(dialog, box, dialogW, dialogH)
 	}
 
+	if m.showHelp {
+		return overlayCenter(dialog, m.renderEditorHelp(), dialogW, dialogH)
+	}
+
 	return dialog
 }
 
@@ -651,7 +673,7 @@ func (m *EditorModel) renderEditorKeyHints(width int) string {
 	type hint struct{ key, desc string }
 	hints := []hint{
 		{"a", "追加"}, {"e", "編集"}, {"d", "削除"},
-		{"Tab", "切替"}, {"Esc", "戻る"},
+		{"Tab", "切替"}, {"?", "ヘルプ"}, {"Esc", "戻る"},
 	}
 	var parts []string
 	for _, h := range hints {
@@ -1241,4 +1263,115 @@ func (m *EditorModel) renderWindowFormBox() string {
 		Padding(1, 2).
 		Width(w).
 		Render(sb.String())
+}
+
+func (m *EditorModel) renderEditorHelp() string {
+	type entry struct{ key, desc string }
+	type section struct {
+		title   string
+		entries []entry
+	}
+	sections := []section{
+		{"ナビゲーション", []entry{
+			{"j / k", "上 / 下移動"},
+			{"h / l", "左 / 右パネル移動"},
+			{"Tab", "パネル切替"},
+			{"1 / 2", "パネル直接指定"},
+		}},
+		{"操作", []entry{
+			{"a", "追加"},
+			{"e", "編集"},
+			{"d", "削除"},
+			{"w / Ctrl+S", "保存"},
+		}},
+		{"フォーム内", []entry{
+			{"Tab / Shift+Tab", "フィールド移動"},
+			{"e", "ディレクトリ入力モード"},
+			{"h / l", "レイアウト選択"},
+			{"Space", "Execute トグル"},
+			{"Enter", "確定"},
+			{"Esc", "キャンセル"},
+		}},
+		{"その他", []entry{
+			{"?", "ヘルプ"},
+			{"Esc", "エディタを閉じる"},
+		}},
+	}
+
+	const keyW = 16
+	keyStyle := lipgloss.NewStyle().Foreground(colorCyan).Bold(true).Width(keyW)
+	descStyle := lipgloss.NewStyle().Foreground(colorFg)
+	secTitleStyle := lipgloss.NewStyle().Foreground(colorPurple).Bold(true)
+	bdrStyle := lipgloss.NewStyle().Foreground(colorBorder)
+	dimStyle := lipgloss.NewStyle().Foreground(colorFgDim)
+
+	colContentW := 36
+	pad := 2
+	colStyle := lipgloss.NewStyle().Width(colContentW+pad*2).Padding(1, pad)
+	descMaxW := colContentW - keyW - 1
+	descIndent := strings.Repeat(" ", keyW+1)
+
+	wrapDesc := func(text string) string {
+		if runewidth.StringWidth(text) <= descMaxW {
+			return text
+		}
+		var lines []string
+		var cur strings.Builder
+		curW := 0
+		for _, r := range text {
+			rw := runewidth.RuneWidth(r)
+			if curW+rw > descMaxW && cur.Len() > 0 {
+				lines = append(lines, cur.String())
+				cur.Reset()
+				curW = 0
+			}
+			cur.WriteRune(r)
+			curW += rw
+		}
+		if cur.Len() > 0 {
+			lines = append(lines, cur.String())
+		}
+		return strings.Join(lines, "\n"+descIndent)
+	}
+
+	renderSection := func(sec section) string {
+		lines := []string{
+			secTitleStyle.Render(sec.title),
+			bdrStyle.Render(strings.Repeat("─", colContentW)),
+		}
+		for _, e := range sec.entries {
+			lines = append(lines, keyStyle.Render(e.key)+" "+descStyle.Render(wrapDesc(e.desc)))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	leftBlock := colStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		renderSection(sections[0]), "", renderSection(sections[3]),
+	))
+	rightBlock := colStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		renderSection(sections[1]), "", renderSection(sections[2]),
+	))
+
+	colH := lipgloss.Height(leftBlock)
+	if rh := lipgloss.Height(rightBlock); rh > colH {
+		colH = rh
+	}
+	divLines := make([]string, colH)
+	for i := range divLines {
+		divLines[i] = bdrStyle.Render("│")
+	}
+	divider := strings.Join(divLines, "\n")
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top, leftBlock, divider, rightBlock)
+	bodyW := lipgloss.Width(body)
+
+	footer := lipgloss.NewStyle().Padding(0, pad).Render(
+		dimStyle.Render("? / Esc / q で閉じる"),
+	)
+	sepLine := bdrStyle.Render(strings.Repeat("─", bodyW))
+	inner := lipgloss.JoinVertical(lipgloss.Left, sepLine, body, sepLine, footer)
+
+	innerH := lipgloss.Height(inner)
+	innerW := lipgloss.Width(inner)
+	return panelBorderColored(inner, innerW+2, innerH+2, 0, "Keybindings", colorYellow, colorYellow)
 }

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -199,7 +199,7 @@ func (m *ScanModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.skipCmd(m.cursor)
 		}
 
-	case "enter", "s":
+	case "enter":
 		if m.isHeader(m.cursor) {
 			m.showSkipped = !m.showSkipped
 			break


### PR DESCRIPTION
## Summary

- **キーの統一**: `d`=削除（エディタのみ）、`x`=セッション停止、`Enter`=プライマリアクション に整理
- **s/S ペア**: `s`=スキャン実行、`S`=スキャンディレクトリ設定（旧`n`→`s`、旧`c`→`n`）
- **h/l ナビゲーション**: メイン・エディタ画面でパネル横移動（vim スタイル）
- **J/K 並び替え**: プロジェクトを任意の順に移動・保存。アクティブ優先ソート中は自動解除
- **ソート修正**: アルファベット順タイブレーカーを削除し、同一グループ内はカスタム順を保持
- **エディタヘルプ**: `?` でヘルプダイアログ表示、`Ctrl+S` 保存を追加
- **ヘルプ充実**: 全キーをヘルプダイアログに記載、フッターキーヒントも更新
- **折り返し修正**: ヘルプダイアログの長い説明文が正しくインデントされて折り返されるよう修正

## Test plan

- [ ] `Enter` でセッション起動/アタッチ、`s` キーは起動しない
- [ ] `x` でセッション停止、`d` キーは停止しない
- [ ] `s` でスキャン画面、`S` でスキャンディレクトリ設定、`n` で新規セッション作成
- [ ] メイン画面で `h`/`l` でパネルフォーカス移動
- [ ] エディタ画面で `h`/`l` でパネル切替（フォームなし時）、フォーム内では既存のレイアウト選択が動作
- [ ] `J`/`K` でプロジェクト順番変更・config 保存される
- [ ] `o` でソート切替（アクティブ優先↔カスタム順）
- [ ] メイン画面 `?` でヘルプ表示、エディタ画面 `?` でヘルプ表示
- [ ] エディタで `Ctrl+S` 保存
- [ ] ヘルプダイアログの長い説明文が正しくインデントされて折り返される

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)