### PR TITLE
Fix editor panel layout and keybindings improvements

### DIFF
--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -644,7 +644,7 @@ func (m *EditorModel) buildEditorDialog(w, h int) string {
 		panelH = 4
 	}
 
-	leftW := innerW / 3
+	leftW := innerW / 2
 	if leftW < 22 {
 		leftW = 22
 	}
@@ -698,9 +698,37 @@ func (m *EditorModel) renderWindowPanel(totalW, totalH int) string {
 		}
 		if i == m.winCursor {
 			if m.panel == editorPanelWindows {
-				lines = append(lines, styleSelectedItem.Width(innerW).Render(
-					fmt.Sprintf(" ▸ %s%s", w.Name, layoutSuffix),
-				))
+				rawLayout := ""
+				if isNamedLayout(w.Layout) {
+					rawLayout = w.Layout
+				} else if w.Layout != "" {
+					rawLayout = "[カスタム]"
+				}
+				layoutSuffixW := 0
+				if rawLayout != "" {
+					layoutSuffixW = runewidth.StringWidth("  " + rawLayout)
+				}
+				nameMaxW := innerW - runewidth.StringWidth(" ▸ ") - layoutSuffixW
+				if nameMaxW < 1 {
+					nameMaxW = 1
+				}
+				truncatedName := truncateStr(w.Name, nameMaxW)
+				nameRendered := lipgloss.NewStyle().
+					Background(colorSelected).Foreground(colorBlue).Bold(true).
+					Render(" ▸ " + truncatedName)
+				layoutRendered := ""
+				if rawLayout != "" {
+					layoutRendered = lipgloss.NewStyle().
+						Background(colorSelected).Foreground(lipgloss.Color("#497fab")).
+						Render("  " + rawLayout)
+				}
+				usedW := runewidth.StringWidth(" ▸ "+truncatedName) + layoutSuffixW
+				padW := innerW - usedW
+				if padW < 0 {
+					padW = 0
+				}
+				pad := lipgloss.NewStyle().Background(colorSelected).Render(strings.Repeat(" ", padW))
+				lines = append(lines, nameRendered+layoutRendered+pad)
 			} else {
 				lines = append(lines, lipgloss.NewStyle().Foreground(colorCyan).Width(innerW).Render(
 					fmt.Sprintf(" ▸ %s%s", w.Name, layoutSuffix),
@@ -742,9 +770,11 @@ func (m *EditorModel) renderPanePanel(totalW, totalH int) string {
 	var lines []string
 	if win != nil {
 		for i, pane := range win.Panes {
-			execStr := styleDim.Render("▷")
+			execChar := "▷"
+			execStr := styleDim.Render(execChar)
 			if pane.Execute {
-				execStr = styleRed.Render("▶")
+				execChar = "▶"
+				execStr = styleRed.Render(execChar)
 			}
 			dir := pane.Dir
 			if dir == "" {
@@ -776,7 +806,7 @@ func (m *EditorModel) renderPanePanel(totalW, totalH int) string {
 			if i == m.paneCursor {
 				if m.panel == editorPanelPanes {
 					top = styleSelectedItem.Width(innerW).Render(
-						fmt.Sprintf(" pane %d  %s  %s", i, execStr, truncateStr(dir, dirMaxW)),
+						fmt.Sprintf(" pane %d  %s  %s", i, execChar, truncateStr(dir, dirMaxW)),
 					)
 					bot = lipgloss.NewStyle().
 						Background(colorBg2).Foreground(colorYellow).Width(innerW).

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -17,7 +17,7 @@ var (
 	colorCyan        = lipgloss.Color("#7dcfff")
 	colorBlue        = lipgloss.Color("#7aa2f7")
 	colorPurple      = lipgloss.Color("#bb9af7")
-	colorSelected    = lipgloss.Color("#2d3f1e") // 緑がかった選択色
+	colorSelected    = lipgloss.Color("#30477a") // 青がかった選択色
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 
 	styleSelectedItem = lipgloss.NewStyle().
 				Background(colorSelected).
-				Foreground(colorGreen).
+				Foreground(colorBlue).
 				Bold(true)
 
 	styleDim = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary

- Windows/Panes パネルの幅比率を 1/3:2/3 → 50:50 に変更し、ウィンドウ名が見切れる問題を修正
- 選択中ウィンドウのレンダリングでレイアウトサフィックスを考慮したトランケート処理を実装
- 選択色を緑系 (`#2d3f1e`) から青系 (`#30477a`) に変更し、デザインの一貫性を改善

## Test plan

- [ ] 編集画面を開き、ウィンドウ名が正しく表示されることを確認
- [ ] 長いウィンドウ名が適切にトランケートされることを確認
- [ ] Windows/Panes パネルが均等幅で表示されることを確認
- [ ] 選択ハイライトが青系の色で表示されることを確認

close #15 

🤖 Generated with [Claude Code](https://claude.com/claude-code)