### PR TITLE
Revamp skip to hidden: move skipped items to project list bottom

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -70,7 +70,8 @@ type App struct {
 	setup         *SetupModel
 	quickstart    *QuickstartModel
 
-	showHelp bool
+	showHelp   bool
+	showHidden bool
 }
 
 // New はAppを生成する
@@ -331,6 +332,9 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.scanner != nil {
 			m.scanner.Resize(ws.Width, ws.Height)
 		}
+		if m.setup != nil {
+			m.setup.Resize(ws.Width, ws.Height)
+		}
 		if m.quickstart != nil {
 			m.quickstart.Resize(ws.Width, ws.Height)
 		}
@@ -372,8 +376,6 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentScreen = screenMain
 				m.setup = nil
 				if skipped {
-					// スキップ時はリロードしない（再度reloadedMsgが来ないのでsetup画面も出ない）
-					// 次回起動時はScanDirectoryが空なので再度setup画面に遷移する
 					return m, nil
 				}
 				return m, reloadCmd
@@ -530,10 +532,33 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "h":
-		m.focus = panelProjects
+		if m.focus == panelProjects && m.isHiddenHeader() {
+			m.showHidden = false
+		} else {
+			m.focus = panelProjects
+		}
 
 	case "l":
-		m.focus = panelDetail
+		if m.focus == panelProjects && m.isHiddenHeader() {
+			m.showHidden = true
+		} else {
+			m.focus = panelDetail
+		}
+
+	case " ":
+		if m.focus == panelProjects && m.isHiddenHeader() {
+			m.showHidden = !m.showHidden
+		}
+
+	case "left":
+		if m.focus == panelProjects && m.isHiddenHeader() {
+			m.showHidden = false
+		}
+
+	case "right":
+		if m.focus == panelProjects && m.isHiddenHeader() {
+			m.showHidden = true
+		}
 
 	case "1":
 		m.focus = panelProjects
@@ -542,7 +567,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.focus = panelDetail
 
 	case "r":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			return m, nil
 		}
 		m.status = "更新中..."
@@ -551,7 +576,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "j", "down":
 		if m.focus == panelProjects {
-			if m.cfg != nil && m.cursor < len(m.cfg.Projects)-1 {
+			if m.cfg != nil && m.cursor < m.totalListItems()-1 {
 				m.cursor++
 				m.detailScroll = 0
 				m.adjustListScroll()
@@ -579,14 +604,14 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.detailScroll = 0
 
 	case "G":
-		if m.cfg != nil && len(m.cfg.Projects) > 0 {
-			m.cursor = len(m.cfg.Projects) - 1
+		if m.cfg != nil && m.totalListItems() > 0 {
+			m.cursor = m.totalListItems() - 1
 			m.detailScroll = 0
 			m.adjustListScroll()
 		}
 
 	case "enter":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		p := m.cfg.Projects[m.cursor]
@@ -602,7 +627,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, startSessionCmd(p, false)
 
 	case "x":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		p := m.cfg.Projects[m.cursor]
@@ -615,7 +640,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, killSessionCmd(p.Name)
 
 	case "e":
-		if m.cfg != nil && len(m.cfg.Projects) > 0 {
+		if m.cfg != nil && len(m.cfg.Projects) > 0 && m.cursor < len(m.cfg.Projects) {
 			m.editor = NewEditor(m.cfg, m.cursor)
 			m.editor.Resize(m.width, m.height)
 			m.currentScreen = screenEditor
@@ -630,7 +655,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "R":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		p := m.cfg.Projects[m.cursor]
@@ -642,7 +667,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.confirmTarget = p.Name
 
 	case "a":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		m.cfg.Projects[m.cursor].AutoStart = !m.cfg.Projects[m.cursor].AutoStart
@@ -694,13 +719,46 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "X":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 {
+		if m.cfg == nil {
+			break
+		}
+		if hi := m.hiddenProjectIdx(); hi >= 0 {
+			// 非表示→通常リストへ復元
+			hidden := m.hiddenItems()
+			p := hidden[hi]
+			// HiddenProjects から削除（あれば）
+			for i, hp := range m.cfg.HiddenProjects {
+				if hp.Path == p.Path {
+					m.cfg.HiddenProjects = append(m.cfg.HiddenProjects[:i], m.cfg.HiddenProjects[i+1:]...)
+					break
+				}
+			}
+			// SkippedPaths から削除
+			for i, sp := range m.cfg.SkippedPaths {
+				if sp == p.Path {
+					m.cfg.SkippedPaths = append(m.cfg.SkippedPaths[:i], m.cfg.SkippedPaths[i+1:]...)
+					break
+				}
+			}
+			m.cfg.Projects = append(m.cfg.Projects, p)
+			if m.cursor >= m.totalListItems() && m.cursor > 0 {
+				m.cursor--
+			}
+			if err := config.Save(m.cfg); err != nil {
+				m.status = fmt.Sprintf("保存エラー: %v", err)
+				m.statusIsErr = true
+			} else {
+				m.status = fmt.Sprintf("'%s' を非表示から復元しました", p.Name)
+				m.statusIsErr = false
+			}
+			return m, reloadCmd
+		}
+		if len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		p := m.cfg.Projects[m.cursor]
 		m.cfg.Projects = append(m.cfg.Projects[:m.cursor], m.cfg.Projects[m.cursor+1:]...)
 		m.cfg.HiddenProjects = append(m.cfg.HiddenProjects, p)
-		m.cfg.SkippedPaths = append(m.cfg.SkippedPaths, p.Path)
 		if m.cursor >= len(m.cfg.Projects) && m.cursor > 0 {
 			m.cursor--
 		}
@@ -708,13 +766,13 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = fmt.Sprintf("保存エラー: %v", err)
 			m.statusIsErr = true
 		} else {
-			m.status = fmt.Sprintf("'%s' をスキップ済みへ移動しました", p.Name)
+			m.status = fmt.Sprintf("'%s' を非表示へ移動しました", p.Name)
 			m.statusIsErr = false
 		}
 		return m, reloadCmd
 
 	case "K":
-		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor == 0 {
+		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor == 0 || m.cursor >= len(m.cfg.Projects) {
 			break
 		}
 		if m.sortActiveFirst {
@@ -868,6 +926,65 @@ func (m *App) visibleListItems() int {
 	return items
 }
 
+// hiddenItems は非表示セクションに表示する全アイテムを返す。
+// HiddenProjects に加え、SkippedPaths のみに存在する（スキャン画面でスキップした）
+// エントリも含む。
+func (m *App) hiddenItems() []config.Project {
+	if m.cfg == nil {
+		return nil
+	}
+	items := make([]config.Project, len(m.cfg.HiddenProjects))
+	copy(items, m.cfg.HiddenProjects)
+	inHidden := map[string]bool{}
+	for _, p := range m.cfg.HiddenProjects {
+		inHidden[p.Path] = true
+	}
+	for _, path := range m.cfg.SkippedPaths {
+		if !inHidden[path] {
+			items = append(items, config.Project{
+				Name: filepath.Base(path),
+				Path: path,
+			})
+		}
+	}
+	return items
+}
+
+func (m *App) totalListItems() int {
+	if m.cfg == nil {
+		return 0
+	}
+	hidden := m.hiddenItems()
+	n := len(m.cfg.Projects)
+	if len(hidden) > 0 {
+		n++ // 非表示ヘッダー
+		if m.showHidden {
+			n += len(hidden)
+		}
+	}
+	return n
+}
+
+func (m *App) isHiddenHeader() bool {
+	return m.cfg != nil && len(m.hiddenItems()) > 0 &&
+		m.cursor == len(m.cfg.Projects)
+}
+
+func (m *App) hiddenProjectIdx() int {
+	if m.cfg == nil || !m.showHidden {
+		return -1
+	}
+	hidden := m.hiddenItems()
+	if len(hidden) == 0 {
+		return -1
+	}
+	hi := m.cursor - len(m.cfg.Projects) - 1
+	if hi >= 0 && hi < len(hidden) {
+		return hi
+	}
+	return -1
+}
+
 // ─── View ─────────────────────────────────────────────────────────────────────
 
 func (m *App) View() string {
@@ -978,7 +1095,7 @@ func (m *App) renderHelpDialog(bg string) string {
 			{"A", "自動起動を全て起動"},
 			{"K / J", "順番を上 / 下に移動"},
 			{"o", "ソート切替（アクティブ優先 / カスタム順）"},
-			{"X", "スキップ済みへ移動"},
+				{"X", "非表示へ移動 / 復元"},
 		}},
 		{"スキャン", []entry{
 			{"s", "スキャン実行"},
@@ -1307,12 +1424,19 @@ func (m *App) renderProjectList(totalW, totalH int) string {
 
 	var lines []string
 	if m.cfg != nil {
-		end := m.listScroll + visibleH
-		if end > len(m.cfg.Projects) {
-			end = len(m.cfg.Projects)
+		nameW := innerW - 5
+		if nameW < 1 {
+			nameW = 1
 		}
-		for i := m.listScroll; i < end; i++ {
-			p := m.cfg.Projects[i]
+
+		// 通常プロジェクト
+		for i, p := range m.cfg.Projects {
+			if i < m.listScroll {
+				continue
+			}
+			if len(lines) >= visibleH {
+				break
+			}
 			running := m.sessions[p.Name]
 
 			dot := styleDim.Render("○")
@@ -1324,10 +1448,6 @@ func (m *App) renderProjectList(totalW, totalH int) string {
 				star = styleYellow.Render("★")
 			}
 
-			nameW := innerW - 5
-			if nameW < 1 {
-				nameW = 1
-			}
 			name := p.Name
 			if len(name) > nameW {
 				name = name[:nameW-1] + "…"
@@ -1342,13 +1462,51 @@ func (m *App) renderProjectList(totalW, totalH int) string {
 				if p.AutoStart {
 					starRaw = "★"
 				}
-				line := styleSelectedItem.Width(innerW).Render(
+				lines = append(lines, styleSelectedItem.Width(innerW).Render(
 					fmt.Sprintf("%s%s %-*s ", starRaw, dotRaw, nameW, name),
-				)
-				lines = append(lines, line)
+				))
 			} else {
-				line := fmt.Sprintf("%s%s %-*s ", star, dot, nameW, styleNormal.Render(name))
-				lines = append(lines, line)
+				lines = append(lines, fmt.Sprintf("%s%s %-*s ", star, dot, nameW, styleNormal.Render(name)))
+			}
+		}
+
+		// 非表示セクション
+		if hidden := m.hiddenItems(); len(hidden) > 0 {
+			headerAbsPos := len(m.cfg.Projects)
+			if headerAbsPos >= m.listScroll && len(lines) < visibleH {
+				arrow := "▶"
+				if m.showHidden {
+					arrow = "▼"
+				}
+				headerText := fmt.Sprintf("%s 非表示 (%d)", arrow, len(hidden))
+				if m.cursor == headerAbsPos {
+					lines = append(lines, styleSelectedItem.Width(innerW).Render(headerText))
+				} else {
+					lines = append(lines, styleDimBold.Render(headerText))
+				}
+			}
+
+			if m.showHidden {
+				for hi, p := range hidden {
+					absPos := len(m.cfg.Projects) + 1 + hi
+					if absPos < m.listScroll {
+						continue
+					}
+					if len(lines) >= visibleH {
+						break
+					}
+					name := p.Name
+					if len(name) > nameW {
+						name = name[:nameW-1] + "…"
+					}
+					if m.cursor == absPos {
+						lines = append(lines, styleSelectedItem.Width(innerW).Render(
+							fmt.Sprintf("   %-*s ", nameW, name),
+						))
+					} else {
+						lines = append(lines, fmt.Sprintf("   %-*s ", nameW, styleDim.Render(name)))
+					}
+				}
 			}
 		}
 	}

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -17,11 +17,8 @@ type ScanModel struct {
 	cfg           *config.Config
 
 	projects []config.ScannedProject
-	skipped  []config.ScannedProject
 	cursor   int
 	selected map[int]bool
-
-	showSkipped bool
 
 	status      string
 	statusIsErr bool
@@ -32,14 +29,11 @@ type ScanModel struct {
 // ─── メッセージ ───────────────────────────────────────────────────────────────
 
 type scanLoadedMsg struct {
-	newProjects     []config.ScannedProject
-	skippedProjects []config.ScannedProject
-	err             error
+	newProjects []config.ScannedProject
+	err         error
 }
 
 type scanSavedMsg struct{ err error }
-
-type scanSkipMsg struct{ err error }
 
 // ─── コンストラクタ ───────────────────────────────────────────────────────────
 
@@ -65,7 +59,7 @@ func (m *ScanModel) LoadCmd() tea.Cmd {
 	cfg := m.cfg
 	return func() tea.Msg {
 		result, err := config.ScanNewProjects(cfg)
-		return scanLoadedMsg{newProjects: result.New, skippedProjects: result.Skipped, err: err}
+		return scanLoadedMsg{newProjects: result.New, err: err}
 	}
 }
 
@@ -73,31 +67,7 @@ func (m *ScanModel) LoadCmd() tea.Cmd {
 
 // totalItems はカーソルが動ける全アイテム数を返す
 func (m *ScanModel) totalItems() int {
-	n := len(m.projects)
-	if len(m.skipped) > 0 {
-		n++ // スキップ済みヘッダー
-		if m.showSkipped {
-			n += len(m.skipped)
-		}
-	}
-	return n
-}
-
-// isHeader はカーソル位置がスキップ済みヘッダーかどうか
-func (m *ScanModel) isHeader(idx int) bool {
-	return len(m.skipped) > 0 && idx == len(m.projects)
-}
-
-// skippedIdx はカーソル位置に対応する m.skipped のインデックスを返す（-1: 対象外）
-func (m *ScanModel) skippedIdx(cursorPos int) int {
-	if !m.showSkipped || len(m.skipped) == 0 {
-		return -1
-	}
-	si := cursorPos - len(m.projects) - 1
-	if si >= 0 && si < len(m.skipped) {
-		return si
-	}
-	return -1
+	return len(m.projects)
 }
 
 // ─── Update ──────────────────────────────────────────────────────────────────
@@ -111,7 +81,6 @@ func (m *ScanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusIsErr = true
 		} else {
 			m.projects = msg.newProjects
-			m.skipped = msg.skippedProjects
 			m.updateStatus()
 		}
 
@@ -123,15 +92,6 @@ func (m *ScanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.done = true
 		}
 
-	case scanSkipMsg:
-		if msg.err != nil {
-			m.status = fmt.Sprintf("保存エラー: %s", msg.err)
-			m.statusIsErr = true
-		} else {
-			m.updateStatus()
-			m.statusIsErr = false
-		}
-
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -139,10 +99,8 @@ func (m *ScanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *ScanModel) updateStatus() {
-	if len(m.projects) == 0 && len(m.skipped) == 0 {
+	if len(m.projects) == 0 {
 		m.status = "新規プロジェクトは見つかりませんでした"
-	} else if len(m.skipped) > 0 {
-		m.status = fmt.Sprintf("%d 件の未登録プロジェクトを発見  /  スキップ済み: %d 件", len(m.projects), len(m.skipped))
 	} else {
 		m.status = fmt.Sprintf("%d 件の未登録プロジェクトを発見", len(m.projects))
 	}
@@ -164,10 +122,6 @@ func (m *ScanModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case " ":
-		if m.isHeader(m.cursor) {
-			m.showSkipped = !m.showSkipped
-			break
-		}
 		if m.cursor < len(m.projects) {
 			m.selected[m.cursor] = !m.selected[m.cursor]
 			if m.cursor < len(m.projects)-1 {
@@ -176,7 +130,6 @@ func (m *ScanModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "a":
-		// 全選択/全解除（通常プロジェクトのみ）
 		if len(m.selected) == len(m.projects) {
 			m.selected = map[int]bool{}
 		} else {
@@ -185,25 +138,7 @@ func (m *ScanModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-	case "x":
-		if m.isHeader(m.cursor) {
-			m.showSkipped = !m.showSkipped
-			break
-		}
-		if si := m.skippedIdx(m.cursor); si >= 0 {
-			// スキップ解除
-			return m, m.unskipCmd(si)
-		}
-		if m.cursor < len(m.projects) {
-			// スキップに追加
-			return m, m.skipCmd(m.cursor)
-		}
-
 	case "enter":
-		if m.isHeader(m.cursor) {
-			m.showSkipped = !m.showSkipped
-			break
-		}
 		if len(m.selected) == 0 {
 			m.status = "プロジェクトが選択されていません"
 			m.statusIsErr = true
@@ -212,54 +147,6 @@ func (m *ScanModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.saveCmd()
 	}
 	return m, nil
-}
-
-func (m *ScanModel) skipCmd(idx int) tea.Cmd {
-	p := m.projects[idx]
-	// 選択状態をずらす
-	newSelected := map[int]bool{}
-	for i, sel := range m.selected {
-		if i < idx && sel {
-			newSelected[i] = true
-		} else if i > idx && sel {
-			newSelected[i-1] = true
-		}
-	}
-	m.selected = newSelected
-	// projects から取り出して skipped へ
-	m.projects = append(m.projects[:idx], m.projects[idx+1:]...)
-	m.skipped = append(m.skipped, p)
-	if m.cursor >= m.totalItems() && m.cursor > 0 {
-		m.cursor--
-	}
-	// config に保存
-	m.cfg.SkippedPaths = append(m.cfg.SkippedPaths, p.Path)
-	cfg := m.cfg
-	return func() tea.Msg {
-		return scanSkipMsg{err: config.Save(cfg)}
-	}
-}
-
-func (m *ScanModel) unskipCmd(si int) tea.Cmd {
-	p := m.skipped[si]
-	// skipped から取り出して projects へ
-	m.skipped = append(m.skipped[:si], m.skipped[si+1:]...)
-	m.projects = append(m.projects, p)
-	// SkippedPaths から削除
-	for i, sp := range m.cfg.SkippedPaths {
-		if sp == p.Path {
-			m.cfg.SkippedPaths = append(m.cfg.SkippedPaths[:i], m.cfg.SkippedPaths[i+1:]...)
-			break
-		}
-	}
-	// カーソルがずれないよう調整
-	if m.cursor >= m.totalItems() && m.cursor > 0 {
-		m.cursor--
-	}
-	cfg := m.cfg
-	return func() tea.Msg {
-		return scanSkipMsg{err: config.Save(cfg)}
-	}
 }
 
 func (m *ScanModel) saveCmd() tea.Cmd {
@@ -318,7 +205,7 @@ func (m *ScanModel) buildScanDialog(w, h int) string {
 	var listContent string
 	if m.loading {
 		listContent = styleDim.Render("スキャン中...")
-	} else if len(m.projects) == 0 && len(m.skipped) == 0 {
+	} else if len(m.projects) == 0 {
 		scanDir := m.cfg.Settings.ScanDirectory
 		if scanDir == "" {
 			home, _ := os.UserHomeDir()
@@ -361,7 +248,7 @@ func (m *ScanModel) renderScanStatusW(w int) string {
 func (m *ScanModel) renderScanKeysW(w int) string {
 	type hint struct{ key, desc string }
 	hints := []hint{
-		{"Space", "選択"}, {"a", "全選択"}, {"x", "スキップ"}, {"Enter", "追加"}, {"Esc", "戻る"},
+		{"Space", "選択"}, {"a", "全選択"}, {"Enter", "追加"}, {"Esc", "戻る"},
 	}
 	var parts []string
 	for _, h := range hints {
@@ -408,50 +295,6 @@ func (m *ScanModel) renderProjectList(totalW, innerH int) string {
 			lines = append(lines, line)
 		}
 		lineIdx++
-	}
-
-	// スキップ済みセクション
-	if len(m.skipped) > 0 && lineIdx < innerH {
-		arrow := "▶"
-		if m.showSkipped {
-			arrow = "▼"
-		}
-		headerText := fmt.Sprintf("%s スキップ済み (%d)", arrow, len(m.skipped))
-		headerCursorIdx := len(m.projects)
-
-		if m.cursor == headerCursorIdx {
-			lines = append(lines, styleSelectedItem.Width(totalW).Render(headerText))
-		} else {
-			lines = append(lines, styleDimBold.Render(headerText))
-		}
-		lineIdx++
-
-		if m.showSkipped {
-			for si, p := range m.skipped {
-				if lineIdx >= innerH {
-					break
-				}
-				cursorPos := len(m.projects) + 1 + si
-
-				path := p.Path
-				maxPathW := totalW - 26
-				if maxPathW > 0 && len(path) > maxPathW {
-					path = "…" + path[len(path)-maxPathW+1:]
-				}
-
-				skipMark := styleDim.Render("[S]")
-
-				if m.cursor == cursorPos {
-					lines = append(lines, styleSelectedItem.Width(totalW).Render(
-						fmt.Sprintf("%s %-20s  %s", "[S]", p.Name, path),
-					))
-				} else {
-					line := fmt.Sprintf("%s %-20s  %s", skipMark, styleDim.Render(p.Name), styleDim.Render(path))
-					lines = append(lines, line)
-				}
-				lineIdx++
-			}
-		}
 	}
 
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary

- プロジェクト一覧の最下部に折りたたみ式「非表示 (N)」セクションを追加
- Space / ← → / hl キーでヘッダー上から展開・折りたたみ操作
- 非表示項目上で X キーを押すと通常リストへ復元
- スキャン画面からスキップ機能（x キー・スキップ済みセクション）を削除
- HiddenProjects のみ使用、SkippedPaths への新規書き込みを停止（既存データは表示継続）

## Test plan

- [ ] `go build -o muxflow .` が通ること
- [ ] プロジェクト上で X → 一覧最下部に「非表示 (N)」ヘッダーが表示される
- [ ] Space / ←→ / hl で展開・折りたたみが動作する
- [ ] 非表示項目上で X → 通常リストへ復元される
- [ ] スキャン画面 (s) を開いてもスキップ済みセクションが表示されないこと
- [ ] スキャン画面に「x: スキップ」のキーヒントが表示されないこと

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)