### PR TITLE
feat: 再起動確認ダイアログに実行中プロセスを表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-tmuxセッションをTUIで管理するツールです。プロジェクト一覧からセッションを起動・アタッチしたり、PC再起動後にまとめて自動起動したりできます。
+**tmuxのコマンドを覚えなくても、tmuxを使いこなせる。**
+
+`tmux new-session -s myproject` や `tmux attach-session -t myproject`——そんなコマンドを毎回調べていませんか？  
+muxflow は、[lazygit](https://github.com/jesseduffield/lazygit) が git を直感的にしたように、**tmux をキーボード操作だけで扱える TUI ツール**です。
+
+プロジェクト一覧からセッションを起動・アタッチしたり、PC再起動後にまとめて自動起動したりできます。  
+ウィンドウ・ペインの分割レイアウトや、よく使う起動コマンド（`docker compose up`、`npm run dev` など）を登録しておけば、`Enter` 一発でいつでも同じ環境が立ち上がります。
 
 [Bubble Tea](https://github.com/charmbracelet/bubbletea) + [lipgloss](https://github.com/charmbracelet/lipgloss) で実装されています。
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -77,6 +77,30 @@ func KillSession(name string) error {
 	return exec.Command("tmux", "kill-session", "-t", name).Run()
 }
 
+var shellProcesses = map[string]bool{
+	"bash": true, "zsh": true, "sh": true, "fish": true,
+	"tcsh": true, "ksh": true, "dash": true, "csh": true,
+}
+
+// ListActiveProcesses はセッション内で実行中のプロセス名一覧を返す（シェルを除く）
+func ListActiveProcesses(sessionName string) ([]string, error) {
+	code, out := runCmd("list-panes", "-t", sessionName, "-a", "-F", "#{pane_current_command}")
+	if code != 0 {
+		return nil, fmt.Errorf("list-panes failed")
+	}
+	seen := map[string]bool{}
+	var result []string
+	for _, cmd := range strings.Split(out, "\n") {
+		cmd = strings.TrimSpace(cmd)
+		if cmd == "" || shellProcesses[cmd] || seen[cmd] {
+			continue
+		}
+		seen[cmd] = true
+		result = append(result, cmd)
+	}
+	return result, nil
+}
+
 func resolveDir(projectPath, paneDir string) string {
 	paneDir = config.ExpandPath(paneDir)
 	if filepath.IsAbs(paneDir) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -54,7 +54,8 @@ type App struct {
 	listScroll   int
 
 	// 確認ダイアログ
-	confirmTarget string // 確認対象のセッション名（空 = ダイアログ非表示）
+	confirmTarget         string   // 確認対象のセッション名（空 = ダイアログ非表示）
+	confirmActiveProcesses []string // ダイアログ表示用: 実行中プロセス名
 
 	// tmux同期確認ダイアログ
 	pendingSyncCfg      *config.Config
@@ -162,6 +163,11 @@ type sessionRestartedMsg struct {
 
 type switchClientMsg struct {
 	err error
+}
+
+type activeProcessesCheckedMsg struct {
+	projectName string
+	processes   []string
 }
 
 type windowSyncChoice struct {
@@ -310,6 +316,13 @@ func restartSessionCmd(p config.Project) tea.Cmd {
 		}
 		_, err := tmux.CreateSession(&p, false)
 		return sessionRestartedMsg{name: p.Name, err: err}
+	}
+}
+
+func checkActiveProcessesCmd(p config.Project) tea.Cmd {
+	return func() tea.Msg {
+		processes, _ := tmux.ListActiveProcesses(p.Name)
+		return activeProcessesCheckedMsg{projectName: p.Name, processes: processes}
 	}
 }
 
@@ -494,6 +507,11 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, reloadCmd
 
+	case activeProcessesCheckedMsg:
+		m.confirmTarget = msg.projectName
+		m.confirmActiveProcesses = msg.processes
+		return m, nil
+
 	case tea.KeyMsg:
 		if m.pendingSyncCfg != nil {
 			return m.handleSyncConfirmKey(msg)
@@ -664,7 +682,7 @@ func (m *App) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusIsErr = true
 			break
 		}
-		m.confirmTarget = p.Name
+		return m, checkActiveProcessesCmd(p)
 
 	case "a":
 		if m.cfg == nil || len(m.cfg.Projects) == 0 || m.cursor >= len(m.cfg.Projects) {
@@ -832,6 +850,7 @@ func (m *App) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "Y":
 		name := m.confirmTarget
 		m.confirmTarget = ""
+		m.confirmActiveProcesses = nil
 		if m.cfg == nil {
 			break
 		}
@@ -844,6 +863,7 @@ func (m *App) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "n", "N", "esc":
 		m.confirmTarget = ""
+		m.confirmActiveProcesses = nil
 	}
 	return m, nil
 }
@@ -1620,8 +1640,23 @@ func (m *App) renderConfirmDialog(bg string) string {
 		dialogW = dw
 	}
 
+	var parts []string
+	parts = append(parts, line1)
+	if len(m.confirmActiveProcesses) > 0 {
+		parts = append(parts, "")
+		parts = append(parts, styleYellow.Render("⚠  以下のプロセスが実行中です:"))
+		for _, proc := range m.confirmActiveProcesses {
+			procLine := styleDim.Render("  • ") + styleNormal.Render(proc)
+			parts = append(parts, procLine)
+			if w := lipgloss.Width(procLine) + 6; w > dialogW {
+				dialogW = w
+			}
+		}
+	}
+	parts = append(parts, "", line2)
+
 	inner := lipgloss.NewStyle().Padding(1, 2).Width(dialogW).
-		Render(lipgloss.JoinVertical(lipgloss.Center, line1, "", line2))
+		Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
 	innerW := lipgloss.Width(inner)
 	innerH := lipgloss.Height(inner)
 	dialog := panelBorderColored(inner, innerW+2, innerH+2, 0, "再起動確認", colorYellow, colorYellow)


### PR DESCRIPTION
## Summary

- 再起動確認ダイアログで、tmuxペインで動いているプロセス名（シェル除く）を警告表示
- 誤って起動中のサーバやビルドプロセスを落とすリスクを低減
- README冒頭にlazygitリスペクトのキャッチコピーを追加し、tmuxコマンド不要の訴求を強化

## Test plan

- [ ] 何かプロセスが動いているセッションで `r` を押し、ダイアログにプロセス名が表示されることを確認
- [ ] シェルのみのセッションで `r` を押し、プロセス一覧が表示されないことを確認
- [ ] `y` / `n` / `Esc` でダイアログが正常に閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)