### PR TITLE
feat: gistからtmuxコンフィグ・チートシートをHTTP取得して適用する

### DIFF
--- a/internal/tmuxconf/tmuxconf.go
+++ b/internal/tmuxconf/tmuxconf.go
@@ -2,8 +2,15 @@ package tmuxconf
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+)
+
+const (
+	ConfigGistURL     = "https://gist.githubusercontent.com/masaway/4d86173343b90d96f74a9c77447a61c7/raw/.tmux.conf"
+	CheatsheetGistURL = "https://gist.githubusercontent.com/masaway/421857eb1959fb5ac73fe453dbb483c8/raw/.tmux-cheatsheet.txt"
 )
 
 // RecommendedConfig はツール制作者推奨の tmux 設定
@@ -82,6 +89,44 @@ set -g focus-events on
 # muxflow: PREFIX+m で起動
 bind m new-window -n "muxflow" "muxflow"
 `
+
+// FetchURL は指定URLの内容をHTTP GETで取得して返す
+func FetchURL(url string) (string, error) {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("取得失敗: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTPエラー: %d", resp.StatusCode)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("読み込み失敗: %w", err)
+	}
+	return string(b), nil
+}
+
+// CheatsheetPath は ~/.tmux-cheatsheet.txt のフルパスを返す
+func CheatsheetPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".tmux-cheatsheet.txt")
+}
+
+// ApplyContent は指定コンテンツを ~/.tmux.conf に書き込む
+func ApplyContent(content string, backup bool) error {
+	if backup && Exists() {
+		if err := os.Rename(ConfigPath(), BackupPath()); err != nil {
+			return fmt.Errorf("バックアップ失敗: %w", err)
+		}
+	}
+	return os.WriteFile(ConfigPath(), []byte(content), 0644)
+}
+
+// ApplyCheatsheet は指定コンテンツを ~/.tmux-cheatsheet.txt に書き込む
+func ApplyCheatsheet(content string) error {
+	return os.WriteFile(CheatsheetPath(), []byte(content), 0644)
+}
 
 // ConfigPath は ~/.tmux.conf のフルパスを返す
 func ConfigPath() string {

--- a/internal/ui/tmuxconf.go
+++ b/internal/ui/tmuxconf.go
@@ -12,10 +12,11 @@ import (
 type tmuxConfState int
 
 const (
-	tmuxConfStateSelect  tmuxConfState = iota // 初期選択画面
-	tmuxConfStateConfirm                      // 既存ファイルあり確認ダイアログ
-	tmuxConfStateDone                         // 適用完了
-	tmuxConfStatePreview                      // 設定内容プレビュー
+	tmuxConfStateSelect   tmuxConfState = iota // 初期選択画面
+	tmuxConfStateConfirm                       // 既存ファイルあり確認ダイアログ
+	tmuxConfStateFetching                      // gistから取得中
+	tmuxConfStateDone                          // 適用完了
+	tmuxConfStatePreview                       // 設定内容プレビュー
 )
 
 // TmuxConfModel は tmux 推奨設定画面
@@ -27,6 +28,11 @@ type TmuxConfModel struct {
 	confirmCursor int // 0=backup+apply, 1=overwrite, 2=cancel
 	doneCursor    int // 0=continue, 1=restore
 	wasBackedUp   bool
+	pendingBackup bool // fetch後に適用するバックアップ設定
+
+	fetchedConfig     string
+	fetchedCheatsheet string
+	cheatsheetApplied bool
 
 	previewScroll int
 	previewLines  []string
@@ -35,9 +41,16 @@ type TmuxConfModel struct {
 	statusIsErr bool
 }
 
+type tmuxConfFetchedMsg struct {
+	config     string
+	cheatsheet string
+	err        error
+}
+
 type tmuxConfAppliedMsg struct {
-	backedUp bool
-	err      error
+	backedUp          bool
+	cheatsheetApplied bool
+	err               error
 }
 
 type tmuxConfRestoredMsg struct {
@@ -62,6 +75,20 @@ func (m *TmuxConfModel) Resize(w, h int) {
 
 func (m *TmuxConfModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tmuxConfFetchedMsg:
+		if msg.err != nil {
+			m.status = "gist取得失敗（ローカル設定を使用）: " + msg.err.Error()
+			m.statusIsErr = true
+			m.fetchedConfig = ""
+			m.fetchedCheatsheet = ""
+		} else {
+			m.status = ""
+			m.statusIsErr = false
+			m.fetchedConfig = msg.config
+			m.fetchedCheatsheet = msg.cheatsheet
+		}
+		return m, applyTmuxConfCmd(m.pendingBackup, m.fetchedConfig, m.fetchedCheatsheet)
+
 	case tmuxConfAppliedMsg:
 		if msg.err != nil {
 			m.status = "エラー: " + msg.err.Error()
@@ -69,9 +96,12 @@ func (m *TmuxConfModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.state = tmuxConfStateSelect
 		} else {
 			m.wasBackedUp = msg.backedUp
+			m.cheatsheetApplied = msg.cheatsheetApplied
 			m.doneCursor = 0
 			m.state = tmuxConfStateDone
-			m.status = ""
+			if m.status == "" {
+				m.status = ""
+			}
 		}
 		return m, nil
 
@@ -90,6 +120,11 @@ func (m *TmuxConfModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSelect(msg)
 		case tmuxConfStateConfirm:
 			return m.updateConfirm(msg)
+		case tmuxConfStateFetching:
+			// 取得中はCtrl+Cのみ受け付ける
+			if msg.String() == "ctrl+c" {
+				m.done = true
+			}
 		case tmuxConfStateDone:
 			return m.updateDone(msg)
 		case tmuxConfStatePreview:
@@ -106,7 +141,9 @@ func (m *TmuxConfModel) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.confirmCursor = 0
 			m.state = tmuxConfStateConfirm
 		} else {
-			return m, applyTmuxConfCmd(false)
+			m.pendingBackup = false
+			m.state = tmuxConfStateFetching
+			return m, fetchGistCmd()
 		}
 	case "p":
 		m.previewScroll = 0
@@ -127,9 +164,13 @@ func (m *TmuxConfModel) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		switch m.confirmCursor {
 		case 0:
-			return m, applyTmuxConfCmd(true)
+			m.pendingBackup = true
+			m.state = tmuxConfStateFetching
+			return m, fetchGistCmd()
 		case 1:
-			return m, applyTmuxConfCmd(false)
+			m.pendingBackup = false
+			m.state = tmuxConfStateFetching
+			return m, fetchGistCmd()
 		case 2:
 			m.state = tmuxConfStateSelect
 		}
@@ -186,11 +227,39 @@ func (m *TmuxConfModel) updatePreview(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func applyTmuxConfCmd(backup bool) tea.Cmd {
+func fetchGistCmd() tea.Cmd {
+	return func() tea.Msg {
+		config, err := tmuxconf.FetchURL(tmuxconf.ConfigGistURL)
+		if err != nil {
+			return tmuxConfFetchedMsg{err: err}
+		}
+		cheatsheet, err := tmuxconf.FetchURL(tmuxconf.CheatsheetGistURL)
+		if err != nil {
+			return tmuxConfFetchedMsg{err: err}
+		}
+		return tmuxConfFetchedMsg{config: config, cheatsheet: cheatsheet}
+	}
+}
+
+func applyTmuxConfCmd(backup bool, config, cheatsheet string) tea.Cmd {
 	return func() tea.Msg {
 		backedUp := backup && tmuxconf.Exists()
-		err := tmuxconf.Apply(backup)
-		return tmuxConfAppliedMsg{backedUp: backedUp, err: err}
+		var err error
+		if config != "" {
+			err = tmuxconf.ApplyContent(config, backup)
+		} else {
+			err = tmuxconf.Apply(backup)
+		}
+		if err != nil {
+			return tmuxConfAppliedMsg{backedUp: backedUp, err: err}
+		}
+		cheatsheetApplied := false
+		if cheatsheet != "" {
+			if cerr := tmuxconf.ApplyCheatsheet(cheatsheet); cerr == nil {
+				cheatsheetApplied = true
+			}
+		}
+		return tmuxConfAppliedMsg{backedUp: backedUp, cheatsheetApplied: cheatsheetApplied}
 	}
 }
 
@@ -209,6 +278,8 @@ func (m *TmuxConfModel) View() string {
 		body = m.viewSelect()
 	case tmuxConfStateConfirm:
 		body = m.viewConfirm()
+	case tmuxConfStateFetching:
+		body = m.viewFetching()
 	case tmuxConfStateDone:
 		body = m.viewDone()
 	case tmuxConfStatePreview:
@@ -236,6 +307,13 @@ func (m *TmuxConfModel) View() string {
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, panel, statusLine, m.renderKeys())
+}
+
+func (m *TmuxConfModel) viewFetching() string {
+	return lipgloss.JoinVertical(lipgloss.Left,
+		"",
+		styleDim.Render("gist からコンフィグを取得中..."),
+	)
 }
 
 func (m *TmuxConfModel) viewSelect() string {
@@ -304,6 +382,13 @@ func (m *TmuxConfModel) viewDone() string {
 	var lines []string
 	lines = append(lines, "", ok, "")
 
+	if m.cheatsheetApplied {
+		lines = append(lines,
+			styleGreen.Render("✓ ~/.tmux-cheatsheet.txt を配置しました"),
+			"",
+		)
+	}
+
 	if m.wasBackedUp {
 		lines = append(lines,
 			styleDim.Render("元の設定は ~/.tmux.conf.bak に保存されています。"),
@@ -366,6 +451,8 @@ func (m *TmuxConfModel) renderKeys() string {
 			{"p", "内容を表示"},
 			{"q / Esc", "スキップ"},
 		}
+	case tmuxConfStateFetching:
+		// 取得中はキーヒントなし
 	case tmuxConfStateConfirm:
 		hints = []struct{ key, desc string }{
 			{"j/k", "移動"},


### PR DESCRIPTION
## 概要

セットアップ画面でtmux設定を適用する際、コードにハードコードされた設定ではなくGistから最新コンテンツを取得するように変更しました。

## 変更内容

- **`internal/tmuxconf/tmuxconf.go`**
  - GistのURL定数を追加（`ConfigGistURL`, `CheatsheetGistURL`）
  - `FetchURL()`: HTTP GETでgistコンテンツを取得
  - `ApplyContent()`: 指定コンテンツを `~/.tmux.conf` に書き込む
  - `ApplyCheatsheet()`: チートシートを `~/.tmux-cheatsheet.txt` に書き込む

- **`internal/ui/tmuxconf.go`**
  - `tmuxConfStateFetching` 状態を追加（取得中の表示）
  - 適用選択時にgistからHTTP取得 → 取得後に適用するフローに変更
  - チートシートも同時に配置し、完了画面に表示
  - HTTP失敗時は `RecommendedConfig` にフォールバック

## テスト手順

- [ ] `go build -o muxflow .` でビルドが通ること
- [ ] TmuxConf画面でEnterを押すと「gist からコンフィグを取得中...」が表示される
- [ ] 完了後 `cat ~/.tmux.conf` でgistと同じ内容になっていること
- [ ] 完了後 `cat ~/.tmux-cheatsheet.txt` でチートシートが配置されていること
- [ ] ネットワーク切断状態でもフォールバックで適用できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)