### PR TITLE
fix: 削除済みディレクトリがプロジェクト一覧・非表示一覧に残るバグ修正

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,8 +126,36 @@ func Load() (*Config, error) {
 	return &cfg, nil
 }
 
+// cleanupStale は存在しないディレクトリのエントリを設定から除去する
+func cleanupStale(cfg *Config) {
+	projects := cfg.Projects[:0]
+	for _, p := range cfg.Projects {
+		if _, err := os.Stat(p.Path); err == nil {
+			projects = append(projects, p)
+		}
+	}
+	cfg.Projects = projects
+
+	hidden := cfg.HiddenProjects[:0]
+	for _, p := range cfg.HiddenProjects {
+		if _, err := os.Stat(p.Path); err == nil {
+			hidden = append(hidden, p)
+		}
+	}
+	cfg.HiddenProjects = hidden
+
+	skipped := cfg.SkippedPaths[:0]
+	for _, path := range cfg.SkippedPaths {
+		if _, err := os.Stat(path); err == nil {
+			skipped = append(skipped, path)
+		}
+	}
+	cfg.SkippedPaths = skipped
+}
+
 // Save は設定を ~/.config/muxflow/config.json に保存する
 func Save(cfg *Config) error {
+	cleanupStale(cfg)
 	dir := configDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- `Save()` 呼び出し時に `cleanupStale()` を実行し、ファイルシステム上に存在しないディレクトリのエントリを自動削除
- `Projects`・`HiddenProjects`・`SkippedPaths` の3つのフィールドすべてをクリーンアップ対象とした

## Test plan
- [ ] 存在しないパスのプロジェクトを config.json に手動追加し、起動後に何らかの操作（プロジェクト追加など）を行うと該当エントリが消えることを確認
- [ ] 有効なプロジェクトは引き続き表示されることを確認
- [ ] `hidden_projects` や `skipped_paths` に存在しないパスを追加して同様に検証

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)