### PR TITLE
fix: セッション更新確認ダイアログで他セッションのプロセスが表示されるバグを修正

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -84,7 +84,7 @@ var shellProcesses = map[string]bool{
 
 // ListActiveProcesses はセッション内で実行中のプロセス名一覧を返す（シェルを除く）
 func ListActiveProcesses(sessionName string) ([]string, error) {
-	code, out := runCmd("list-panes", "-t", sessionName, "-a", "-F", "#{pane_current_command}")
+	code, out := runCmd("list-panes", "-t", sessionName, "-s", "-F", "#{pane_current_command}")
 	if code != 0 {
 		return nil, fmt.Errorf("list-panes failed")
 	}


### PR DESCRIPTION
## Summary

- `tmux list-panes` の `-a` フラグ（全セッション対象）を `-s` フラグ（指定セッション内の全ウィンドウ）に変更
- `R` キーによるセッション再起動確認ダイアログに、対象セッション以外のプロセスが混入していた問題を解消

Closes #28

## Test plan

- [ ] 複数のtmuxセッションが起動している状態で `R` キーを押す
- [ ] 確認ダイアログに表示されるプロセスが対象セッションのものだけであることを確認
- [ ] 他セッションのプロセスが混入しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)