### PR TITLE
fix: セッション起動時のコマンド入力タイミング問題を修正

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -163,7 +163,7 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 		}
 
 		if firstWindow {
-			runCmd("new-session", "-d", "-s", name, "-c", path, "-n", window.Name)
+			runCmd("new-session", "-d", "-s", name, "-c", firstPaneDir, "-n", window.Name)
 			firstWindow = false
 		} else {
 			runCmd("new-window", "-t", name, "-n", window.Name, "-c", firstPaneDir)
@@ -180,12 +180,6 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 			}
 
 			paneTarget := fmt.Sprintf("%s.%d", winTarget, paneIdx)
-
-			// new-session で作られた pane 0 はプロジェクトルートで始まるため、
-			// 指定ディレクトリが異なる場合は cd で移動する
-			if paneIdx == 0 && winIdx == 0 && paneDir != path {
-				runCmd("send-keys", "-t", paneTarget, "cd "+shellQuote(paneDir), "Enter")
-			}
 
 			if pane.Command != "" {
 				cmd := joinCommand(pane.Command)


### PR DESCRIPTION
## Summary
- `new-session` をプロジェクトルートではなく pane 0 の指定ディレクトリで起動するよう変更
- `cd` コマンドを `send-keys` で送る処理を削除
- `cd` 完了前に次のコマンドが届くレースコンディションを解消

## 問題
セッション起動時に pane 0 のディレクトリがプロジェクトルートと異なる場合、`cd` コマンドと実行コマンドを連続して `send-keys` で送っていたため、シェルが `cd` を処理する前に次のコマンドが届き、誤ったディレクトリでコマンドが実行されていた。

## 修正
`new-session -c` に pane 0 の指定ディレクトリを直接渡すことで、最初から正しいディレクトリで起動するようにした。

## Test plan
- [ ] pane 0 に Dir が設定されたプロジェクトでセッションを起動し、正しいディレクトリでコマンドが実行されることを確認
- [ ] Dir が設定されていないプロジェクト（プロジェクトルート起動）が引き続き正常動作することを確認
- [ ] 複数ペイン構成でも各ペインが正しいディレクトリで起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)