### PR TITLE
fix: respect window cwd when splitting panes

### DIFF
--- a/internal/tmux/kill_socket_test.go
+++ b/internal/tmux/kill_socket_test.go
@@ -1,0 +1,128 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/masaway/muxflow/internal/config"
+)
+
+func TestKillSessionUsesConfiguredSocket(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	const socketName = "muxflow-test-kill-socket"
+	const sessionName = "muxflow-test-kill-session"
+
+	SetSocket(socketName)
+	defer SetSocket("")
+	defer exec.Command("tmux", "-L", socketName, "kill-server").Run()
+
+	if out, err := exec.Command("tmux", "-L", socketName, "new-session", "-d", "-s", sessionName).CombinedOutput(); err != nil {
+		t.Fatalf("new-session failed: %v: %s", err, out)
+	}
+
+	if err := KillSession(sessionName); err != nil {
+		t.Fatalf("KillSession failed: %v", err)
+	}
+
+	if out, err := exec.Command("tmux", "-L", socketName, "has-session", "-t", sessionName).CombinedOutput(); err == nil {
+		t.Fatalf("session still exists: %s", out)
+	}
+}
+
+func TestCreateSessionUsesReturnedTargetsForPaneDirectories(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	const socketName = "muxflow-test-pane-targets"
+	const sessionName = "muxflow-test-pane-dirs"
+
+	root := t.TempDir()
+	dirs := []string{"w0a", "w0b", "w1a", "w1b", "w2a", "w2b", "w3a", "w3b"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	SetSocket(socketName)
+	defer SetSocket("")
+	defer exec.Command("tmux", "-L", socketName, "kill-server").Run()
+
+	project := config.Project{
+		Name: sessionName,
+		Path: root,
+		Windows: []config.Window{
+			{Name: "w0", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "w0a"}, {Dir: "w0b"}}},
+			{Name: "w1", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "w1a"}, {Dir: "w1b"}}},
+			{Name: "w2", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "w2a"}, {Dir: "w2b"}}},
+			{Name: "w3", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "w3a"}, {Dir: "w3b"}}},
+		},
+	}
+
+	created, err := CreateSession(&project, false)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	if !created {
+		t.Fatal("CreateSession returned created=false")
+	}
+
+	code, out := runCmd("list-panes", "-t", sessionName, "-s", "-F", "#{window_name}|#{pane_index}|#{pane_current_path}")
+	if code != 0 {
+		t.Fatalf("list-panes failed")
+	}
+
+	got := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		parts := strings.Split(line, "|")
+		if len(parts) != 3 {
+			continue
+		}
+		got[parts[0]+"|"+parts[1]] = filepath.Clean(parts[2])
+	}
+
+	want := map[string]string{
+		"w0|0": filepath.Join(root, "w0a"),
+		"w0|1": filepath.Join(root, "w0b"),
+		"w1|0": filepath.Join(root, "w1a"),
+		"w1|1": filepath.Join(root, "w1b"),
+		"w2|0": filepath.Join(root, "w2a"),
+		"w2|1": filepath.Join(root, "w2b"),
+		"w3|0": filepath.Join(root, "w3a"),
+		"w3|1": filepath.Join(root, "w3b"),
+	}
+	for target, expected := range want {
+		if got[target] != filepath.Clean(expected) {
+			t.Fatalf("%s cwd = %q, want %q\nall panes:\n%s", target, got[target], filepath.Clean(expected), out)
+		}
+	}
+
+	code, optionOut := runCmd("show-window-options", "-v", "-t", sessionName+":w3", "@muxflow_window_dir")
+	if code != 0 {
+		t.Fatalf("@muxflow_window_dir was not set")
+	}
+	if filepath.Clean(optionOut) != filepath.Join(root, "w3a") {
+		t.Fatalf("@muxflow_window_dir = %q, want %q", optionOut, filepath.Join(root, "w3a"))
+	}
+
+	runCmd("select-window", "-t", sessionName+":w3")
+	runCmd("select-pane", "-t", sessionName+":w3.1")
+	code, _ = runCmd("split-window", "-c", "#{?@muxflow_window_dir,#{@muxflow_window_dir},#{pane_current_path}}")
+	if code != 0 {
+		t.Fatalf("split-window with @muxflow_window_dir failed")
+	}
+	code, out = runCmd("display-message", "-p", "-t", sessionName+":w3.2", "#{pane_current_path}")
+	if code != 0 {
+		t.Fatalf("display-message for new pane failed")
+	}
+	if filepath.Clean(out) != filepath.Join(root, "w3a") {
+		t.Fatalf("new pane cwd = %q, want %q", out, filepath.Join(root, "w3a"))
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/masaway/muxflow/internal/config"
 )
@@ -125,6 +126,19 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+func waitPaneCurrentPath(target, expectedPath string) {
+	expectedPath = filepath.Clean(expectedPath)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		code, out := runCmd("display-message", "-p", "-t", target, "#{pane_current_path}")
+		if code == 0 && filepath.Clean(strings.TrimSpace(out)) == expectedPath {
+			time.Sleep(50 * time.Millisecond)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // CreateSession はプロジェクト設定からtmuxセッションを作成する
 func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 	name := project.Name
@@ -182,6 +196,7 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 			paneTarget := fmt.Sprintf("%s.%d", winTarget, paneIdx)
 
 			if pane.Command != "" {
+				waitPaneCurrentPath(paneTarget, paneDir)
 				cmd := joinCommand(pane.Command)
 				if pane.Execute {
 					runCmd("send-keys", "-t", paneTarget, cmd, "Enter")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -75,7 +75,16 @@ func SessionExists(name string) bool {
 
 // KillSession は指定セッションを停止する
 func KillSession(name string) error {
-	return exec.Command("tmux", "kill-session", "-t", name).Run()
+	cmd := exec.Command("tmux", socketArgs([]string{"kill-session", "-t", name})...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+		return err
+	}
+	return nil
 }
 
 var shellProcesses = map[string]bool{
@@ -139,6 +148,14 @@ func waitPaneCurrentPath(target, expectedPath string) {
 	}
 }
 
+func parseWindowPaneTarget(out string, fallbackWindow, fallbackPane string) (string, string) {
+	parts := strings.SplitN(strings.TrimSpace(out), "|", 2)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1]
+	}
+	return fallbackWindow, fallbackPane
+}
+
 // CreateSession はプロジェクト設定からtmuxセッションを作成する
 func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 	name := project.Name
@@ -168,7 +185,7 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 
 	firstWindow := true
 	for winIdx, window := range project.Windows {
-		winTarget := fmt.Sprintf("%s:%d", name, winIdx)
+		fallbackWinTarget := fmt.Sprintf("%s:%d", name, winIdx)
 
 		// pane 0 のディレクトリ（new-window に使う）
 		firstPaneDir := path
@@ -176,24 +193,34 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 			firstPaneDir = resolveDir(path, window.Panes[0].Dir)
 		}
 
+		winTarget := fallbackWinTarget
+		paneTargets := map[int]string{0: fmt.Sprintf("%s.0", fallbackWinTarget)}
 		if firstWindow {
-			runCmd("new-session", "-d", "-s", name, "-c", firstPaneDir, "-n", window.Name)
+			_, out := runCmd("new-session", "-d", "-P", "-F", "#{window_id}|#{pane_id}", "-s", name, "-c", firstPaneDir, "-n", window.Name)
+			winTarget, paneTargets[0] = parseWindowPaneTarget(out, fallbackWinTarget, paneTargets[0])
 			firstWindow = false
 		} else {
-			runCmd("new-window", "-t", name, "-n", window.Name, "-c", firstPaneDir)
+			_, out := runCmd("new-window", "-P", "-F", "#{window_id}|#{pane_id}", "-t", name, "-n", window.Name, "-c", firstPaneDir)
+			winTarget, paneTargets[0] = parseWindowPaneTarget(out, fallbackWinTarget, paneTargets[0])
 		}
+		runCmd("set-window-option", "-t", winTarget, "@muxflow_window_dir", firstPaneDir)
 
 		for paneIdx, pane := range window.Panes {
 			paneDir := resolveDir(path, pane.Dir)
 
 			if paneIdx > 0 {
-				runCmd("split-window", "-t", winTarget, "-c", paneDir)
+				_, out := runCmd("split-window", "-P", "-F", "#{pane_id}", "-t", winTarget, "-c", paneDir)
+				if paneID := strings.TrimSpace(out); paneID != "" {
+					paneTargets[paneIdx] = paneID
+				} else {
+					paneTargets[paneIdx] = fmt.Sprintf("%s.%d", winTarget, paneIdx)
+				}
 				// 分割後すぐにレイアウトを適用することで、ペインが小さくなりすぎて
 				// 次の split-window が失敗するのを防ぐ
 				runCmd("select-layout", "-t", winTarget, window.Layout)
 			}
 
-			paneTarget := fmt.Sprintf("%s.%d", winTarget, paneIdx)
+			paneTarget := paneTargets[paneIdx]
 
 			if pane.Command != "" {
 				waitPaneCurrentPath(paneTarget, paneDir)
@@ -207,7 +234,7 @@ func CreateSession(project *config.Project, killExisting bool) (bool, error) {
 		}
 
 		runCmd("select-layout", "-t", winTarget, window.Layout)
-		runCmd("select-pane", "-t", fmt.Sprintf("%s.0", winTarget))
+		runCmd("select-pane", "-t", paneTargets[0])
 	}
 
 	runCmd("select-window", "-t", fmt.Sprintf("%s:0", name))
@@ -270,7 +297,28 @@ func IsInsideTmux() bool {
 
 // SwitchClient はtmuxのswitch-clientを実行する（tmux内専用）
 func SwitchClient(name string) error {
-	return exec.Command("tmux", socketArgs([]string{"switch-client", "-t", name})...).Run()
+	cmd := exec.Command("tmux", socketArgs([]string{"switch-client", "-t", name})...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+		return err
+	}
+	return nil
+}
+
+// CurrentSession は現在のtmuxクライアントのセッション名を返す。
+func CurrentSession() string {
+	if !IsInsideTmux() {
+		return ""
+	}
+	code, out := runCmd("display-message", "-p", "#{session_name}")
+	if code != 0 {
+		return ""
+	}
+	return strings.TrimSpace(out)
 }
 
 // AttachOrSwitch はtmux内ならswitch-client、外ならattach-sessionを実行する
@@ -282,5 +330,8 @@ func AttachOrSwitch(name string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("attach-session failed: %w", err)
+	}
+	return nil
 }

--- a/internal/tmuxconf/tmuxconf.go
+++ b/internal/tmuxconf/tmuxconf.go
@@ -69,8 +69,10 @@ bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
 # ペイン分割
-bind \\ split-window -h
-bind - split-window -v
+bind \\ split-window -h -c "#{?@muxflow_window_dir,#{@muxflow_window_dir},#{pane_current_path}}"
+bind - split-window -v -c "#{?@muxflow_window_dir,#{@muxflow_window_dir},#{pane_current_path}}"
+bind % split-window -h -c "#{?@muxflow_window_dir,#{@muxflow_window_dir},#{pane_current_path}}"
+bind '"' split-window -v -c "#{?@muxflow_window_dir,#{@muxflow_window_dir},#{pane_current_path}}"
 
 # 設定リロード
 bind r source-file ~/.tmux.conf \; display-message "Config reloaded!"

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -48,22 +48,22 @@ type App struct {
 	pendingAttach string
 	initialLoad   bool
 
-	sortActiveFirst   bool
+	sortActiveFirst  bool
 	originalProjects []config.Project // ソート前の順序を保持
 
 	detailScroll int
 	listScroll   int
 
 	// 確認ダイアログ
-	confirmTarget         string   // 確認対象のセッション名（空 = ダイアログ非表示）
+	confirmTarget          string   // 確認対象のセッション名（空 = ダイアログ非表示）
 	confirmActiveProcesses []string // ダイアログ表示用: 実行中プロセス名
 
 	// tmux同期確認ダイアログ
 	pendingSyncCfg      *config.Config
 	pendingSyncSessions map[string]bool
-	pendingSyncNames    []string            // 変更されるプロジェクト名一覧
-	pendingSyncChoices  []windowSyncChoice  // ウィンドウごとの選択状態
-	pendingSyncCursor   int                 // ダイアログ内カーソル位置
+	pendingSyncNames    []string           // 変更されるプロジェクト名一覧
+	pendingSyncChoices  []windowSyncChoice // ウィンドウごとの選択状態
+	pendingSyncCursor   int                // ダイアログ内カーソル位置
 
 	// サブ画面
 	currentScreen screen
@@ -883,6 +883,11 @@ func (m *App) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		for _, p := range m.cfg.Projects {
 			if p.Name == name {
+				if tmux.CurrentSession() == name {
+					m.status = fmt.Sprintf("現在のセッション '%s' は再起動できません", name)
+					m.statusIsErr = true
+					return m, nil
+				}
 				m.status = fmt.Sprintf("再起動中: %s ...", name)
 				m.statusIsErr = false
 				return m, restartSessionCmd(p)
@@ -1146,7 +1151,7 @@ func (m *App) renderHelpDialog(bg string) string {
 			{"A", "自動起動を全て起動"},
 			{"K / J", "順番を上 / 下に移動"},
 			{"o", "ソート切替（アクティブ優先 / カスタム順）"},
-				{"X", "非表示へ移動 / 復元"},
+			{"X", "非表示へ移動 / 復元"},
 		}},
 		{"スキャン", []entry{
 			{"s", "スキャン実行"},
@@ -1167,7 +1172,7 @@ func (m *App) renderHelpDialog(bg string) string {
 
 	colContentW := 40
 	pad := 2
-	colStyle := lipgloss.NewStyle().Width(colContentW + pad*2).Padding(1, pad)
+	colStyle := lipgloss.NewStyle().Width(colContentW+pad*2).Padding(1, pad)
 	descMaxW := colContentW - keyW - 1
 	descIndent := strings.Repeat(" ", keyW+1)
 


### PR DESCRIPTION
## Summary
- wait for tmux panes to reach the configured cwd before sending commands
- store each muxflow window initial directory in @muxflow_window_dir and use returned tmux window/pane IDs instead of inferred indexes
- update recommended split-window bindings to use the muxflow window directory with pane_current_path fallback
- make KillSession respect the configured tmux socket and avoid restarting the currently attached session

## Related
- updated masaway/tmux-config gist source in commit 33ec7b8

## Tests
- go test ./...
- go build -o muxflow .