### PR TITLE
Use latest config when restarting sessions

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -314,12 +314,32 @@ func killSessionCmd(name string) tea.Cmd {
 
 func restartSessionCmd(p config.Project) tea.Cmd {
 	return func() tea.Msg {
+		p = latestProjectConfig(p)
 		if err := tmux.KillSession(p.Name); err != nil {
 			return sessionRestartedMsg{name: p.Name, err: err}
 		}
 		_, err := tmux.CreateSession(&p, false)
 		return sessionRestartedMsg{name: p.Name, err: err}
 	}
+}
+
+func latestProjectConfig(p config.Project) config.Project {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return p
+	}
+
+	for _, latest := range cfg.Projects {
+		if latest.Name == p.Name && latest.Path == p.Path {
+			return latest
+		}
+	}
+	for _, latest := range cfg.Projects {
+		if latest.Name == p.Name {
+			return latest
+		}
+	}
+	return p
 }
 
 func checkActiveProcessesCmd(p config.Project) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/masaway/muxflow/internal/config"
+)
+
+func TestLatestProjectConfigPrefersSavedProjectWithSameNameAndPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	config.SetSocket("ui-latest-project")
+	defer config.SetSocket("")
+
+	root := t.TempDir()
+	stale := config.Project{
+		Name: "crosslog",
+		Path: root,
+		Windows: []config.Window{
+			{Name: "boot", Layout: "tiled", Panes: []config.Pane{{Dir: "."}}},
+		},
+	}
+	latest := config.Project{
+		Name: "crosslog",
+		Path: root,
+		Windows: []config.Window{
+			{Name: "boot", Layout: "tiled", Panes: []config.Pane{{Dir: "."}}},
+			{Name: "crosslog-back", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "crosslog-back"}}},
+		},
+	}
+
+	if err := config.Save(&config.Config{Projects: []config.Project{latest}}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := latestProjectConfig(stale)
+	if len(got.Windows) != len(latest.Windows) {
+		t.Fatalf("windows = %d, want %d", len(got.Windows), len(latest.Windows))
+	}
+	if got.Windows[1].Name != "crosslog-back" {
+		t.Fatalf("window[1].Name = %q, want crosslog-back", got.Windows[1].Name)
+	}
+}
+
+func TestLatestProjectConfigFallsBackToNameWhenPathChanged(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	config.SetSocket("ui-latest-project-path")
+	defer config.SetSocket("")
+
+	oldRoot := t.TempDir()
+	newRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(newRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.Save(&config.Config{Projects: []config.Project{{
+		Name: "crosslog",
+		Path: newRoot,
+		Windows: []config.Window{
+			{Name: "latest", Layout: "even-horizontal", Panes: []config.Pane{{Dir: "."}}},
+		},
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := latestProjectConfig(config.Project{Name: "crosslog", Path: oldRoot})
+	if got.Path != newRoot {
+		t.Fatalf("Path = %q, want %q", got.Path, newRoot)
+	}
+}


### PR DESCRIPTION
## Summary
- reload the saved project config before restarting a tmux session
- prefer exact name/path matches and fall back to project name when resolving the latest config
- add UI tests for latest project config resolution

## Tests
- go test ./...